### PR TITLE
fix notebook paths

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -16,8 +16,6 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v2
-        with:
-          repo-token: ${{ secrets.GITHUBTOKEN }}
       - name: Set up Python 3.10
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -16,6 +16,8 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v2
+        with:
+          repo-token: ${{ secrets.GITHUBTOKEN }}
       - name: Set up Python 3.10
         uses: actions/setup-python@v2
         with:
@@ -34,3 +36,4 @@ jobs:
       - name: Build documentation
         run: make coverage doctest html
         working-directory: docs
+        

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,7 +68,7 @@ autoapi_dirs = ['../eitprocessing']
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = "piccolo"
+html_theme = "nature"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/eitprocessing/binreader/__init__.py
+++ b/eitprocessing/binreader/__init__.py
@@ -1,3 +1,12 @@
 """Loading and processing binary EIT data from the Dräger Pulmovista 500"""
 
 __version__ = "0.1"
+
+from .frameset import Frameset
+from .phases import MaxValue
+from .phases import MinValue
+from .reader import Reader
+from .sequence import Sequence
+
+
+__all__ = ['Frameset', 'MaxValue', 'MinValue', 'Reader',  'Sequence', ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,6 +63,7 @@ dev =
     sphinx-autoapi
     tox
     myst_parser
+    pyroma
 publishing =
     twine
     wheel


### PR DESCRIPTION
I had removed imports from the init in #33 to 'fix' linting issues, but this broke the notebook. I now recovered the imports and added an `__all__` to not tick off the linter.

closes #19 

alternative solution to #51 