### PR TITLE
fix: raise error for illegal vendor of  Sequence child

### DIFF
--- a/eitprocessing/binreader/sequence.py
+++ b/eitprocessing/binreader/sequence.py
@@ -108,11 +108,21 @@ class Sequence:
         Raises:
             NotImplementedError: if the child class for the selected vendor
                 has not yet been implemented.
+            TypeError: if the `vendor` argument does not correspond to the expected
+                vendor for `type(self)`.
         """
 
         if isinstance(self.vendor, str):
             self.vendor = Vendor(self.vendor.lower())
 
+        if (isinstance(self, Sequence)
+            and self.__class__ is not Sequence
+            and not self.__class__.vendor == self.vendor
+            ):
+            raise TypeError(f'`vendor` for {type(self)} cannot be set as {self.vendor}.')
+
+        # Note that this way of re-assigning classes is considered to be a bad practice
+        # (https://tinyurl.com/2x2cea6h), but the objections raised don't seem to be prohibtive.
         if self.vendor == Vendor.DRAEGER:
             self.__class__ = DraegerSequence
         elif self.vendor == Vendor.TIMPEL:

--- a/eitprocessing/binreader/sequence.py
+++ b/eitprocessing/binreader/sequence.py
@@ -117,7 +117,7 @@ class Sequence:
 
         if (isinstance(self, Sequence)
             and self.__class__ is not Sequence
-            and not self.__class__.vendor == self.vendor
+            and self.__class__.vendor != self.vendor
             ):
             raise TypeError(f'`vendor` for {type(self)} cannot be set as {self.vendor}.')
 

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -98,6 +98,18 @@ def test_illegal_from_path():
         _= Sequence.from_path(timpel_file, vendor="sentec")
 
 
+def test_illegal_vendor():
+    _= DraegerSequence(vendor='draeger')
+    with pytest.raises(TypeError):
+        _= DraegerSequence(vendor='timpel')
+        _= DraegerSequence(vendor='sentec')
+
+    _= TimpelSequence(vendor='timpel')
+    with pytest.raises(TypeError):
+        _= TimpelSequence(vendor='draeger')
+        _= TimpelSequence(vendor='sentec')
+
+
 def test_merge(  # pylint: disable=too-many-locals
     draeger_data1: DraegerSequence,
     draeger_data2: DraegerSequence,


### PR DESCRIPTION
setting the `vendor` argument of `Sequence` child class can no longer change the class.

I also added a comment regarding not using best practices (see #93 )

closes: #94 