### PR TITLE
feature add `label` as an argument to `Sequence`

### DIFF
--- a/eitprocessing/binreader/sequence.py
+++ b/eitprocessing/binreader/sequence.py
@@ -5,7 +5,7 @@ Licensed under the Apache License, version 2.0. See LICENSE for details.
 This file contains methods related to parts of electrical impedance tomographs
 as they are read.
 """
-
+from __future__ import annotations
 import bisect
 import copy
 import functools
@@ -121,7 +121,7 @@ class Sequence:
             raise NotImplementedError(f"vendor {self.vendor} is not implemented")
 
     @staticmethod
-    def check_equivalence(a: "Sequence", b: "Sequence"):
+    def check_equivalence(a: Sequence, b: Sequence):
         """Checks whether content of two Sequence objects is equivalent."""
 
         if (a_ := a.vendor) != (b_ := b.vendor):
@@ -134,11 +134,11 @@ class Sequence:
             )
         return True
 
-    def __add__(self, other):
+    def __add__(self, other: Sequence) -> Sequence:
         return self.merge(self, other)
 
     @classmethod
-    def merge(cls, a: "Sequence", b: "Sequence") -> "Sequence":
+    def merge(cls, a: Sequence, b: Sequence) -> Sequence:
         """Merge two Sequence objects together."""
         try:
             Sequence.check_equivalence(a, b)
@@ -183,7 +183,7 @@ class Sequence:
         framerate: int = None,
         first_frame: int = 0,
         max_frames: int | None = None,
-    ) -> "Sequence":
+    ) -> Sequence:
         """Load sequence from path(s)
 
         Args:
@@ -226,7 +226,7 @@ class Sequence:
         framerate: int = None,
         first_frame: int = 0,
         max_frames: int | None = None,
-    ) -> "Sequence":
+    ) -> Sequence:
         """Method used by `from_path` that initiates the object and calls
         child method for loading the data.
 
@@ -302,13 +302,14 @@ class Sequence:
 
         return obj
 
+
     def select_by_time(
         self,
         start: float | int | None = None,
         end: float | int | None = None,
         start_inclusive: bool = True,
         end_inclusive: bool = False,
-    ) -> "Sequence":
+    ) -> Sequence:
         """Select subset of sequence by the `Sequence.time` information (i.e.
         based on the time stamp).
 

--- a/eitprocessing/binreader/sequence.py
+++ b/eitprocessing/binreader/sequence.py
@@ -70,12 +70,12 @@ class Sequence:
         Sequence: a sequence containing the l
     """
 
-    path: Path | str | List[Path | str] = None
-    vendor: Vendor = None
-    label: str = None
-    time: NDArray = None
-    nframes: int = None
-    framerate: int = None
+    path: Path | str | List[Path | str] | None = None
+    vendor: Vendor | str | None = None
+    label: str | None = None
+    time: NDArray | None = None
+    nframes: int | None = None
+    framerate: int | None = None
     framesets: Dict[str, Frameset] = field(default_factory=dict)
     events: List[Event] = field(default_factory=list, repr=False)
     timing_errors: List[TimingError] = field(default_factory=list, repr=False)
@@ -148,7 +148,7 @@ class Sequence:
         cls,
         a: Sequence,
         b: Sequence,
-        label: str = None,
+        label: str | None  = None,
     ) -> Sequence:
         """Create a merge of two Sequence objects."""
 
@@ -194,9 +194,9 @@ class Sequence:
     def from_path(  # pylint: disable=too-many-arguments, unused-argument
         cls,
         path: Path | str | List[Path | str],
-        vendor: Vendor | str = None,
-        label: str = None,
-        framerate: int = None,
+        vendor: Vendor | str | None = None,
+        label: str | None = None,
+        framerate: int | None = None,
         first_frame: int = 0,
         max_frames: int | None = None,
     ) -> Sequence:
@@ -241,8 +241,8 @@ class Sequence:
         cls,
         path: Path | str,
         vendor: Vendor | str,
-        label: str = None,
-        framerate: int = None,
+        label: str | None = None,
+        framerate: int | None = None,
         first_frame: int = 0,
         max_frames: int | None = None,
     ) -> Sequence:
@@ -294,7 +294,11 @@ class Sequence:
         """Needs to be implemented in child class."""
         raise NotImplementedError(f"Data loading for {self.vendor} is not implemented")
 
-    def select_by_index(self, indices: slice, label: str | None = None):
+    def select_by_index(
+        self,
+        indices: slice,
+        label: str | None = None,
+    ):
         if not isinstance(indices, slice):
             raise NotImplementedError(
                 "Slicing only implemented using a slice object"
@@ -333,7 +337,7 @@ class Sequence:
         end: float | int | None = None,
         start_inclusive: bool = True,
         end_inclusive: bool = False,
-        label: str = None,
+        label: str | None = None,
     ) -> Sequence:
         """Select subset of sequence by the `Sequence.time` information (i.e.
         based on the time stamp).
@@ -382,11 +386,10 @@ class Sequence:
 
         return self.select_by_index(slice(start_index,end_index), label = label)
 
-
     def deepcopy(
         self,
-        label: str = None,
-        relabel: bool = True,
+        label: str | None = None,
+        relabel: bool | None = True,
     ) -> Sequence:
         """Create a deep copy of `Sequence` object.
 

--- a/eitprocessing/binreader/sequence.py
+++ b/eitprocessing/binreader/sequence.py
@@ -175,7 +175,7 @@ class Sequence:
                 item.time = time[item.index]
             return a_items + b_items
 
-        label = f'Merge of ({a.label}) and <{b.label}>' if label is None else label
+        label = f'Merge of <{a.label}> and <{b.label}>' if label is None else label
 
         return cls(
             path=path,
@@ -408,7 +408,7 @@ class Sequence:
         if label:
             obj.label = label
         elif relabel:
-            obj.label = f'Deepcopy of {self.label}'
+            obj.label = f'Copy of <{self.label}>'
         return obj
 
 

--- a/eitprocessing/binreader/sequence.py
+++ b/eitprocessing/binreader/sequence.py
@@ -144,8 +144,14 @@ class Sequence:
         return self.merge(self, other)
 
     @classmethod
-    def merge(cls, a: Sequence, b: Sequence) -> Sequence:
-        """Merge two Sequence objects together."""
+    def merge(
+        cls,
+        a: Sequence,
+        b: Sequence,
+        label: str = None,
+    ) -> Sequence:
+        """Create a merge of two Sequence objects."""
+
         try:
             Sequence.check_equivalence(a, b)
         except Exception as e:
@@ -169,9 +175,12 @@ class Sequence:
                 item.time = time[item.index]
             return a_items + b_items
 
+        label = f'Merge of ({a.label}) and <{b.label}>' if label is None else label
+
         return cls(
             path=path,
             vendor=a.vendor,
+            label=label,
             time=time,
             nframes=nframes,
             framerate=a.framerate,

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -372,4 +372,20 @@ def test_label(
     assert timpel_1.label != timpel_copy_relabel.label, 'combo of label and relabel not working as intended'
 
 
+def test_relabeling(
+    timpel_data: TimpelSequence,
+    draeger_data2: DraegerSequence,
+
+):
+    test_label = 'test label'
+
+    #merging
+    merged_timpel = Sequence.merge(timpel_data, timpel_data)
+    assert merged_timpel.label != timpel_data.label, 'merging does not assign new label by default'
+    assert merged_timpel.label == f'Merge of ({timpel_data.label}) and <{timpel_data.label}>', 'merging generates unexpected default label'
+    added_timpel = timpel_data + timpel_data
+    assert added_timpel.label == f'Merge of ({timpel_data.label}) and <{timpel_data.label}>', 'adding generates unexpected default label'
+    merged_timpel_2 = Sequence.merge(timpel_data, timpel_data, label = test_label)
+    assert merged_timpel_2.label == test_label, 'incorrect label assigned when merging data with new label'
+
 

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -389,7 +389,7 @@ def test_relabeling(
     assert merged_timpel_2.label == test_label, 'incorrect label assigned when merging data with new label'
 
     # slicing
-    indices = slice(0,10)
+    indices = slice(0, 10)
     sliced_timpel = timpel_data[indices]
     assert sliced_timpel.label != timpel_data.label, 'slicing does not assign new label by default'
     assert sliced_timpel.label == f'Slice ({indices.start}-{indices.stop}) of <{timpel_data.label}>', 'slicing generates unexpected default label'

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -364,6 +364,7 @@ def test_label(
 
     timpel_copy = timpel_1.deepcopy()
     assert timpel_1.label != timpel_copy.label, 'deepcopied data has identical label'
+    assert timpel_copy.label == f'Copy of <{timpel_1.label}>', 'deepcopied data has unexpected label'
     timpel_copy_relabel = timpel_1.deepcopy(label = test_label)
     assert timpel_1.label != timpel_copy_relabel.label, 'deepcopied data with new label has identical label'
     timpel_copy_relabel = timpel_1.deepcopy(relabel = False)
@@ -382,9 +383,9 @@ def test_relabeling(
     #merging
     merged_timpel = Sequence.merge(timpel_data, timpel_data)
     assert merged_timpel.label != timpel_data.label, 'merging does not assign new label by default'
-    assert merged_timpel.label == f'Merge of ({timpel_data.label}) and <{timpel_data.label}>', 'merging generates unexpected default label'
+    assert merged_timpel.label == f'Merge of <{timpel_data.label}> and <{timpel_data.label}>', 'merging generates unexpected default label'
     added_timpel = timpel_data + timpel_data
-    assert added_timpel.label == f'Merge of ({timpel_data.label}) and <{timpel_data.label}>', 'adding generates unexpected default label'
+    assert added_timpel.label == f'Merge of <{timpel_data.label}> and <{timpel_data.label}>', 'adding generates unexpected default label'
     merged_timpel_2 = Sequence.merge(timpel_data, timpel_data, label = test_label)
     assert merged_timpel_2.label == test_label, 'incorrect label assigned when merging data with new label'
 

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -253,6 +253,7 @@ def test_load_partial(
     assert Sequence.merge(draeger_first_part, draeger_second_part) == draeger_data2
     assert Sequence.merge(draeger_second_part, draeger_first_part) != draeger_data2
 
+
 def test_illegal_first():
     for ff in [0.5, -1, 'fdw']:
         with pytest.raises((TypeError, ValueError)):
@@ -339,3 +340,36 @@ def test_select_by_time(
                                         start_inclusive=False,
                                         end_inclusive=False)
             assert len(sliced) == end_slicing[2]-start_slicing[2]
+
+
+def test_label(
+    draeger_data1: DraegerSequence,
+    draeger_data2: DraegerSequence,
+):
+
+    assert isinstance(draeger_data1.label, str), 'default label is not a string'
+    assert draeger_data1.label == f'Sequence_{id(draeger_data1)}', 'unexpected default label'
+
+    assert draeger_data1.label != draeger_data2.label, 'different data has identical label'
+
+    timpel_1 = Sequence.from_path(timpel_file, vendor = 'timpel')
+    timpel_2 = Sequence.from_path(timpel_file, vendor = 'timpel')
+    assert timpel_1.label != timpel_2.label, 'reloaded data has identical label'
+
+    test_label = 'test_label'
+    timpel_3 = Sequence.from_path(timpel_file, vendor = 'timpel', label = test_label)
+    timpel_4 = Sequence.from_path(timpel_file, vendor = 'timpel', label = test_label)
+    assert timpel_3.label == test_label, 'label attribute does not match given label'
+    assert timpel_3.label == timpel_4.label, 're-used test label not recognized as identical'
+
+    timpel_copy = timpel_1.deepcopy()
+    assert timpel_1.label != timpel_copy.label, 'deepcopied data has identical label'
+    timpel_copy_relabel = timpel_1.deepcopy(label = test_label)
+    assert timpel_1.label != timpel_copy_relabel.label, 'deepcopied data with new label has identical label'
+    timpel_copy_relabel = timpel_1.deepcopy(relabel = False)
+    assert timpel_1.label == timpel_copy_relabel.label, 'deepcopied data did not keep old label'
+    timpel_copy_relabel = timpel_1.deepcopy(label = test_label, relabel = False)
+    assert timpel_1.label != timpel_copy_relabel.label, 'combo of label and relabel not working as intended'
+
+
+

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -388,4 +388,19 @@ def test_relabeling(
     merged_timpel_2 = Sequence.merge(timpel_data, timpel_data, label = test_label)
     assert merged_timpel_2.label == test_label, 'incorrect label assigned when merging data with new label'
 
+    # slicing
+    indices = slice(0,10)
+    sliced_timpel = timpel_data[indices]
+    assert sliced_timpel.label != timpel_data.label, 'slicing does not assign new label by default'
+    assert sliced_timpel.label == f'Slice ({indices.start}-{indices.stop}) of <{timpel_data.label}>', 'slicing generates unexpected default label'
+    sliced_timpel_2 = timpel_data.select_by_index(indices=indices, label=test_label)
+    assert sliced_timpel_2.label == test_label, 'incorrect label assigned when slicing data with new label'
 
+    # select_by_time
+    t22 = 55825.268
+    t52 = 55826.768
+    time_sliced = draeger_data2.select_by_time(t22, t52+0.001)
+    assert time_sliced.label != draeger_data2.label, 'time slicing does not assign new label by default'
+    assert time_sliced.label == f'Slice (22-52) of <{draeger_data2.label}>', 'slicing generates unexpected default label'
+    time_sliced_2 = draeger_data2.select_by_time(t22, t52, label=test_label)
+    assert time_sliced_2.label == test_label, 'incorrect label assigned when time slicing data with new label'


### PR DESCRIPTION
Allowed for `Sequence`s to have a `label` argument, which is intended as a human readable descriptor of the sequence.
If not provided, the object `id` is used instead (is this a good default?)
Slicing and merging methods allow for adding a new label, or auto-generate a descriptive label of the process performed.

closes #98 