### PR TITLE
refactor: remove `__eq__` from `PhaseIndicator`

### DIFF
--- a/eitprocessing/binreader/phases.py
+++ b/eitprocessing/binreader/phases.py
@@ -13,16 +13,6 @@ class PhaseIndicator:
     index: int
     time: float
 
-    # TODO (#78): QUESTION: how does this differ the default __eq__ function for a dataclass?
-    def __eq__(self, other:'PhaseIndicator') -> bool:
-        if self.index != other.index:
-            return False
-        if self.time != other.time:
-            return False
-        if not isinstance(other, type(self)):
-            return False
-        return True
-
 
 @dataclass
 class MinValue(PhaseIndicator):


### PR DESCRIPTION
I believe this is the default `__eq__` for a dataclass anyway. If not, let me know and I will close #78 without making any change instead.

fixes #78