### PR TITLE
mixin class for equality and equivalence

### DIFF
--- a/eitprocessing/continuous_data/continuous_data_variant.py
+++ b/eitprocessing/continuous_data/continuous_data_variant.py
@@ -1,11 +1,12 @@
-from dataclasses import dataclass
-from dataclasses import field
+from dataclasses import dataclass, field
+
 from numpy.typing import NDArray
 from typing_extensions import Self
-from ..variants import Variant
+
+from eitprocessing.variants import Variant
 
 
-@dataclass
+@dataclass(eq=False)
 class ContinuousDataVariant(Variant):
     values: NDArray = field(kw_only=True)
 

--- a/eitprocessing/eit_data/eit_data_variant.py
+++ b/eitprocessing/eit_data/eit_data_variant.py
@@ -1,10 +1,3 @@
-"""
-Copyright 2023 Netherlands eScience Center and Erasmus University Medical Center.
-Licensed under the Apache License, version 2.0. See LICENSE for details.
-
-This file contains methods related to when electrical impedance tomographs are read.
-"""
-
 from dataclasses import dataclass
 from dataclasses import field
 import numpy as np
@@ -70,7 +63,10 @@ class EITDataVariant(Variant, SelectByTime):
         )
 
     def _sliced_copy(
-        self, start_index: int, end_index: int, label: str | None = None
+        self,
+        start_index: int,
+        end_index: int,
+        label: str | None = None,
     ) -> Self:
         pixel_impedance = self.pixel_impedance[start_index:end_index, :, :]
 

--- a/eitprocessing/eit_data/eit_data_variant.py
+++ b/eitprocessing/eit_data/eit_data_variant.py
@@ -7,27 +7,13 @@ from eitprocessing.mixins.slicing import SelectByTime
 from eitprocessing.variants import Variant
 
 
-@dataclass
+@dataclass(eq=False)
 class EITDataVariant(Variant, SelectByTime):
     _data_field_name: str = "pixel_impedance"
     pixel_impedance: NDArray = field(repr=False, kw_only=True)
 
     def __len__(self):
         return self.pixel_impedance.shape[0]
-
-    def __eq__(self, other):
-        for attr in ["name", "description", "params"]:
-            if getattr(self, attr) != getattr(other, attr):
-                return False
-
-        for attr in ["pixel_impedance"]:
-            # NaN values are not equal. Check whether values are equal or both NaN.
-            s = getattr(self, attr)
-            o = getattr(other, attr)
-            if not np.all((s == o) | (np.isnan(s) & np.isnan(o))):
-                return False
-
-        return True
 
     @property
     def global_baseline(self):
@@ -51,7 +37,7 @@ class EITDataVariant(Variant, SelectByTime):
 
     @classmethod
     def concatenate(cls, a: Self, b: Self) -> Self:
-        cls.check_equivalence(a, b, raise_=True)
+        cls.isequivalent(a, b, raise_=True)
 
         return cls(
             label=a.label,

--- a/eitprocessing/eit_data/timpel.py
+++ b/eitprocessing/eit_data/timpel.py
@@ -1,24 +1,23 @@
 import warnings
-from dataclasses import dataclass
-from dataclasses import field
+from dataclasses import dataclass, field
 from pathlib import Path
+
 import numpy as np
 from numpy.typing import NDArray
 from typing_extensions import Self
+
 from eitprocessing.continuous_data.continuous_data_collection import (
     ContinuousDataCollection,
 )
+from eitprocessing.eit_data import EITData_
+from eitprocessing.eit_data.eit_data_variant import EITDataVariant
+from eitprocessing.eit_data.phases import MaxValue, MinValue, QRSMark
+from eitprocessing.eit_data.vendor import Vendor
 from eitprocessing.sparse_data.sparse_data_collection import SparseDataCollection
 from eitprocessing.variants.variant_collection import VariantCollection
-from ..eit_data.eit_data_variant import EITDataVariant
-from ..eit_data.phases import MaxValue
-from ..eit_data.phases import MinValue
-from ..eit_data.phases import QRSMark
-from ..eit_data.vendor import Vendor
-from . import EITData_
 
 
-@dataclass
+@dataclass(eq=False)
 class TimpelEITData(EITData_):
     framerate: float = 50
     vendor: Vendor = field(default=Vendor.TIMPEL, init=False)
@@ -93,7 +92,7 @@ class TimpelEITData(EITData_):
 
         # extract waveform data
         # TODO: properly export waveform data
-        waveform_data = {  # noqa;
+        waveform_data = {  # noqa
             "airway_pressure": data[:, 1024],
             "flow": data[:, 1025],
             "volume": data[:, 1026],

--- a/eitprocessing/helper.py
+++ b/eitprocessing/helper.py
@@ -1,6 +1,2 @@
-class NotEquivalent(Exception):
-    """Raised when two objects are not equivalent."""
-
-
 class NotConsecutive(Exception):
     """Raised when trying to concatenate non-consecutive datasets."""

--- a/eitprocessing/mixins/equality.py
+++ b/eitprocessing/mixins/equality.py
@@ -1,0 +1,31 @@
+from abc import ABC
+from dataclasses import astuple, is_dataclass
+
+import numpy as np
+from typing_extensions import Self
+
+
+class Equivalence(ABC):
+    # inspired by: https://stackoverflow.com/a/51743960/5170442
+    def __eq__(self, other: Self):
+        if self is other:
+            return True
+        if is_dataclass(self):
+            if self.__class__ is not other.__class__:
+                return NotImplemented
+            t1 = astuple(self)
+            t2 = astuple(other)
+            return all(Equivalence._array_safe_eq(a1, a2) for a1, a2 in zip(t1, t2))
+        return Equivalence._array_safe_eq(self, other)
+
+    @staticmethod
+    def _array_safe_eq(a, b) -> bool:
+        """Check if a and b are equal, even if they are numpy arrays containing nans."""
+
+        if isinstance(a, np.ndarray) and isinstance(b, np.ndarray):
+            return a.shape == b.shape and np.array_equal(a, b, equal_nan=True)
+        try:
+            return object.__eq__(a, b)  # `a == b` could trigger an infinite loop
+        except TypeError:
+            return NotImplemented
+

--- a/eitprocessing/mixins/equality.py
+++ b/eitprocessing/mixins/equality.py
@@ -29,3 +29,67 @@ class Equivalence(ABC):
         except TypeError:
             return NotImplemented
 
+    def isequivalent(self, other: Self, raise_: bool = False) -> bool:
+        """Test whether the data structure between two objects are equivalent.
+
+        Equivalence, in this case means that objects are compatible e.g. to be
+        merged. Data content can vary, but e.g. the category of data (e.g.
+        airway pressure, flow, tidal volume) and unit, etc., must match.
+
+
+        Args:
+            other: object that will be compared to self.
+            raise_: sets this method's behavior in case of non-equivalence. If
+                True, an `EquivalenceError` is raised, otherwise `False` is
+                returned.
+
+        Raises:
+            EquivalenceError: if `raise_ == True` and the objects are not
+            equivalent.
+
+        Returns:
+            bool describing result of equivalence comparison.
+        """
+
+        if self == other:
+            return True
+
+        try:
+            # check whether types match
+            if type(self) is not type(other):
+                raise EquivalenceError(
+                    f"Types don't match: {type(self)}, {type(other)}"
+                )
+
+            # check keys in collection
+            if isinstance(self, dict):
+                if set(self.keys()) != set(other.keys()):
+                    raise EquivalenceError(
+                        f"Keys don't match:\n\t{self.keys()},\n\t{other.keys()}"
+                    )
+
+                for key in self:
+                    if not self[key].isequivalent(other[key], False):
+                        raise EquivalenceError(
+                            f"Data in {key} doesn't match: {self[key]}, {other[key]}"
+                        )
+
+            # check attributes of data
+            else:
+                self._check_equivalence: list[str]
+                for attr in self._check_equivalence:
+                    if (s := getattr(self, attr)) != (o := getattr(other, attr)):
+                        raise f"{attr.capitalize()}s don't match: {s}, {o}"
+
+        # raise or return if a check fails
+        except EquivalenceError as e:
+            if raise_:
+                raise e
+            return False
+
+        # if all checks pass
+        return True
+
+
+class EquivalenceError(TypeError, ValueError):
+    """Raised if objects are not equivalent."""

--- a/eitprocessing/mixins/slicing.py
+++ b/eitprocessing/mixins/slicing.py
@@ -12,10 +12,13 @@ from typing_extensions import Self
 class SelectByIndex(ABC):
     """Adds slicing functionality to subclass by implementing `__getitem__`.
 
-    Subclasses must implement a `_sliced_copy` function that defines what should happen
-    when the object is sliced. This class ensures that when calling a slice between
-    square brackets (as e.g. done for lists) then return the expected sliced object.
+    Subclasses must implement a `_sliced_copy` function that defines what should
+    happen when the object is sliced. This class ensures that when calling a
+    slice between square brackets (as e.g. done for lists) then return the
+    expected sliced object.
     """
+
+    label: str
 
     def __getitem__(self, key: slice | int):
         if isinstance(key, slice):
@@ -40,7 +43,12 @@ class SelectByIndex(ABC):
         end: int | None = None,
         label: str | None = None,
     ) -> Self:
-        """De facto implementation of the `__getitem__ function."""
+        """De facto implementation of the `__getitem__ function.
+
+        This function can also be called directly to add a label to the sliced
+        object. Otherwise a default label describing the slice and original
+        object is attached.
+        """
 
         if start is None and end is None:
             warnings.warn("No starting or end timepoint was selected.")
@@ -95,22 +103,22 @@ class SelectByTime(SelectByIndex):
             start_time: first time point to include. Defaults to first frame of sequence.
             end_time: last time point. Defaults to last frame of sequence.
             start_inclusive (default: `True`), end_inclusive (default `False`):
-                these arguments control the behavior if the given time stamp does not
-                match exactly with an existing time stamp of the input.
+                these arguments control the behavior if the given time stamp
+                does not match exactly with an existing time stamp of the input.
                 if `True`: the given time stamp will be inside the sliced object.
                 if `False`: the given time stamp will be outside the sliced object.
-            label: Description. Defaults to None, which will create a label based on the original
-                object label and the frames by which it is sliced.
+            label: Description. Defaults to None, which will create a label based
+                on the original object label and the frames by which it is sliced.
 
         Raises:
             TypeError: if `self` does not contain a `time` attribute.
             ValueError: if time stamps are not sorted.
 
         Returns:
-            Self: _description_
+            Slice of self.
         """
 
-        if not "time" in vars(self):
+        if "time" not in vars(self):
             raise TypeError(f"Object {self} has no time axis.")
 
         if start_time is None and end_time is None:
@@ -150,11 +158,11 @@ class SelectByTime(SelectByIndex):
 
 @dataclass
 class TimeIndexer:
-    """Helper class allowing for slicing an object using the time axis rather than indices
+    """Helper class for slicing an object using the time axis instead of indices.
 
     Example:
     ```
-    >>> data = DraegerEITData.from_path(<path>)
+    >>> data = EITData.from_path(<path>, ...)
     >>> tp_start = data.time[1]
     >>> tp_end = data.time[4]
     >>> time_slice = data.t[tp_start:tp_end]

--- a/eitprocessing/mixins/test_eq.ipynb
+++ b/eitprocessing/mixins/test_eq.ipynb
@@ -1,0 +1,200 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from eitprocessing.mixins.slicing import SelectByIndex\n",
+    "from dataclasses import dataclass, is_dataclass\n",
+    "from eitprocessing.eit_data.vendor import Vendor\n",
+    "from eitprocessing.eit_data.draeger import DraegerEITData\n",
+    "from eitprocessing.eit_data.timpel import TimpelEITData\n",
+    "from eitprocessing.eit_data.eit_data_variant import EITDataVariant\n",
+    "from typing_extensions import Self\n",
+    "from eitprocessing.eit_data import EITData\n",
+    "from eitprocessing.mixins.equality import EquivalenceError\n",
+    "\n",
+    "import os\n",
+    "import pytest\n",
+    "from pprint import pprint\n",
+    "import bisect\n",
+    "import numpy as np\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([72758.105, 72758.155, 72758.205, ..., 73357.955, 73358.005,\n",
+       "       73358.055])"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data = DraegerEITData.from_path('/home/dbodor/git/EIT-ALIVE/eitprocessing/tests/test_data/Draeger_Test2.bin')\n",
+    "data2 = DraegerEITData.from_path('/home/dbodor/git/EIT-ALIVE/eitprocessing/tests/test_data/Draeger_Test3.bin')\n",
+    "timpel_data = TimpelEITData.from_path('/home/dbodor/git/EIT-ALIVE/eitprocessing/tests/test_data/Timpel_Test.txt')\n",
+    "\n",
+    "# pprint(data)\n",
+    "data.time\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "should be True\n",
+      "True\n",
+      "True\n",
+      "True\n",
+      "True\n",
+      "\n",
+      "should be False\n",
+      "False\n",
+      "False\n",
+      "False\n",
+      "False\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/dbodor/git/EIT-ALIVE/eitprocessing/eitprocessing/mixins/slicing.py:52: UserWarning: No starting or end timepoint was selected.\n",
+      "  warnings.warn(\"No starting or end timepoint was selected.\")\n"
+     ]
+    }
+   ],
+   "source": [
+    "print ('should be True')\n",
+    "print(data == data)\n",
+    "print(data[10] == data[10])\n",
+    "print(data[:10] == data[0:10])\n",
+    "print(data[:] == data)\n",
+    "\n",
+    "\n",
+    "print('\\nshould be False')\n",
+    "print(data == data2)\n",
+    "print(data[:10] == data[10])\n",
+    "print(data[:10] == data[2:10])\n",
+    "print(data[:10] == data)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "should all be True\n",
+      "True\n",
+      "True\n",
+      "True\n",
+      "\n",
+      "should all be False\n",
+      "False\n",
+      "False\n",
+      "False\n",
+      "False\n",
+      "\n",
+      "error was correctly raised\n"
+     ]
+    }
+   ],
+   "source": [
+    "print('should all be True')\n",
+    "print(data.isequivalent(data))\n",
+    "print(data.isequivalent(data2))\n",
+    "print(DraegerEITData.isequivalent(data, data2))\n",
+    "\n",
+    "print('\\nshould all be False')\n",
+    "print(data.isequivalent(timpel_data, False))\n",
+    "print(timpel_data.isequivalent(data))\n",
+    "print(EITData.isequivalent(timpel_data, data))\n",
+    "print(DraegerEITData.isequivalent(timpel_data, data))\n",
+    "\n",
+    "try:\n",
+    "    _ = DraegerEITData.isequivalent(timpel_data, data, True)\n",
+    "    print('\\nno error was raised, but it should have!')\n",
+    "except EquivalenceError:\n",
+    "    print('\\nerror was correctly raised')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "should print False/True/False and then catch error\n",
+      "\n",
+      "False\n",
+      "True\n",
+      "False\n",
+      "\n",
+      "error was correctly raised\n"
+     ]
+    }
+   ],
+   "source": [
+    "data_new = DraegerEITData.from_path('/home/dbodor/git/EIT-ALIVE/eitprocessing/tests/test_data/Draeger_Test3.bin')\n",
+    "\n",
+    "print('should print False/True/False and then catch error\\n')\n",
+    "\n",
+    "print(data_new == data)\n",
+    "print(data_new.isequivalent(data))\n",
+    "\n",
+    "data_new.framerate = 25\n",
+    "print(data_new.isequivalent(data))\n",
+    "\n",
+    "try:\n",
+    "    _ = data_new.isequivalent(data, raise_ = True)\n",
+    "    print('\\nno error was raised, but it should have!')\n",
+    "except EquivalenceError:\n",
+    "    print('\\nerror was correctly raised')\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "alive",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tests/mixins/test_eq.py
+++ b/tests/mixins/test_eq.py
@@ -1,0 +1,26 @@
+# OLD FILE. TESTS NOT YET FUNCTIONAL
+
+import bisect
+import os
+from dataclasses import dataclass, is_dataclass
+from pprint import pprint
+
+import numpy as np
+import pytest
+from typing_extensions import Self
+
+from eitprocessing.eit_data.draeger import DraegerEITData
+from eitprocessing.eit_data.eit_data_variant import EITDataVariant
+from eitprocessing.eit_data.vendor import Vendor
+from eitprocessing.mixins.slicing import SelectByIndex
+
+
+def test_eq():
+    data = DraegerEITData.from_path(
+        "/home/dbodor/git/EIT-ALIVE/eitprocessing/tests/test_data/Draeger_Test3.bin"
+    )
+    data2 = DraegerEITData.from_path(
+        "/home/dbodor/git/EIT-ALIVE/eitprocessing/tests/test_data/Draeger_Test3.bin"
+    )
+
+    data.isequivalent(data2)


### PR DESCRIPTION
This PR does the following:

- additions to docstring of slicing module (#132 ) + add init file to mixins subpackage
- create a generic `__eq__` function for alive data structures
- create a generic `isequivalent` function for alive data structures
- apply `isequivalent` throughout