### PR TITLE
129c addition mixin dbodor

### DIFF
--- a/eitprocessing/mixins/addition.py
+++ b/eitprocessing/mixins/addition.py
@@ -1,0 +1,23 @@
+from abc import ABC
+from abc import abstractmethod
+from typing_extensions import Self
+from eitprocessing.mixins.equality import Equivalence
+
+
+class Addition(Equivalence, ABC):
+    def __add__(
+        self,
+        other: Self,
+    ) -> Self:
+        return self.concatenate(other)
+
+    def concatenate(
+        self,
+        other: Self,
+        label: str | None = None,
+    ) -> Self:
+        _ = self.isequivalent(other, raise_=True)
+
+        obj = self.__class__()
+
+        return obj


### PR DESCRIPTION
concatenate should only work if labels match.
this should be overridable if explicitly set (and if so consider requiring explicitly giving a new label).