### PR TITLE
fix: bug fixes on `ContinuousData` class

### DIFF
--- a/eitprocessing/continuous_data/__init__.py
+++ b/eitprocessing/continuous_data/__init__.py
@@ -174,3 +174,26 @@ class ContinuousData(Equivalence, SelectByTime):
     def loaded(self) -> bool:
         """Return whether the data was loaded from disk, or derived from elsewhere."""
         return len(self.derived_from) == 0
+
+    def _sliced_copy(
+        self,
+        start_index: int,
+        end_index: int,
+        label: str,
+    ) -> Self:
+        # TODO: check correct implementation
+        cls = self.__class__
+        time = self.time[start_index:end_index]
+        values = self.values[start_index:end_index]
+        description = f"Slice ({start_index}-{end_index}) of <{self.description}>"
+
+        return cls(
+            label=label,
+            name=self.name,
+            unit=self.unit,
+            category=self.category,
+            description=description,
+            derived_from=[*self.derived_from, self],
+            time=time,
+            values=values,
+        )

--- a/eitprocessing/continuous_data/__init__.py
+++ b/eitprocessing/continuous_data/__init__.py
@@ -45,11 +45,14 @@ class ContinuousData(Equivalence, SelectByTime):
         self.lock("time")
 
     def __setattr__(self, attr: str, value: Any):  # noqa: ANN401
-        old_value = getattr(self, attr)
-        if isinstance(old_value, np.ndarray) and old_value.flags["WRITEABLE"] is False:
-            msg = f"Attribute '{attr}' is locked and can't be overwritten."
-            raise AttributeError(msg)
-        super().__setattr__(self, attr, value)
+        try:
+            old_value = getattr(self, attr)
+            if isinstance(old_value, np.ndarray) and old_value.flags["WRITEABLE"] is False:
+                msg = f"Attribute '{attr}' is locked and can't be overwritten."
+                raise ValueError(msg)
+        except AttributeError:
+            pass
+        super().__setattr__(attr, value)
 
     def copy(
         self,

--- a/eitprocessing/eit_data/draeger.py
+++ b/eitprocessing/eit_data/draeger.py
@@ -113,7 +113,7 @@ class DraegerEITData(EITData_):
             (
                 continuous_data_collection,
                 sparse_data_collections,
-            ) = cls._convert_medibus_data(medibus_data)
+            ) = cls._convert_medibus_data(medibus_data, time)
 
             return (
                 eit_data_collection,
@@ -127,6 +127,7 @@ class DraegerEITData(EITData_):
     def _convert_medibus_data(
         cls,
         medibus_data: NDArray,
+        time: NDArray,
     ) -> tuple[DataCollection, DataCollection]:
         continuous_data_collection = DataCollection(ContinuousData)
         sparse_data_collection = DataCollection(SparseData)
@@ -138,7 +139,7 @@ class DraegerEITData(EITData_):
                     name=field_info.signal_name,
                     description=f"Continuous {field_info.signal_name} data loaded from file",
                     unit=field_info.unit,
-                    loaded=True,
+                    time=time,
                     values=data,
                     category=field_info.signal_name,
                 )


### PR DESCRIPTION
There were a few bugs with the `ContinuousData` class which meant that it was not initializable

- `_sliced_copy` is an abstract method of `SelectByTime`, but wasn't defined in `ContinuousData`, which inherits from it
  - We defined this method now to allow using the class, but still need to check that it is defined correctly
- `_convert_medibus_data` wasn't using `time`, but was still using `loaded`
- `__set_attr__` was trying to read the attributes before they existed during initialization
  - We now wrote is such that the check is skipped when initializing, but is executed when changing the attribute after initialization.
