### PR TITLE
Speed up loading Draeger data over network

### DIFF
--- a/eitprocessing/eit_data/draeger.py
+++ b/eitprocessing/eit_data/draeger.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import mmap
 import sys
 import warnings
 from dataclasses import dataclass, field
@@ -75,7 +76,7 @@ class DraegerEITData(EITData_):
         phases = []
         medibus_data = np.zeros((52, n_frames))
 
-        with path.open("br") as fh:
+        with path.open("br") as fo, mmap.mmap(fo.fileno(), length=0, access=mmap.ACCESS_READ) as fh:
             fh.seek(first_frame_to_load * _FRAME_SIZE_BYTES)
             reader = Reader(fh)
             previous_marker = None


### PR DESCRIPTION
I was working with EITData today and noticed loading Draeger data over network was terribly slow. We solved that problem earlier for SENTEC-data, but not yet for Draeger.

This simple addition using the mmap module speeds up data transfer drastically.
