### PR TITLE
178 datacollection from userdict wbaccinelli

### DIFF
--- a/eitprocessing/datahandling/datacollection.py
+++ b/eitprocessing/datahandling/datacollection.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 V = TypeVar("V", EITData, ContinuousData, SparseData)
 
 
-class DataCollection(UserDict, Equivalence, HasTimeIndexer, Generic[V]):
+class DataCollection(Equivalence, UserDict, HasTimeIndexer, Generic[V]):
     """A collection of a single type of data with unique labels.
 
     This collection functions as a dictionary in most part. When initializing, a data type has to be passed. EITData,

--- a/eitprocessing/datahandling/mixins/equality.py
+++ b/eitprocessing/datahandling/mixins/equality.py
@@ -29,11 +29,9 @@ class Equivalence:
             return all(Equivalence._array_safe_eq(a1, a2) for a1, a2 in zip(t1, t2, strict=True))
 
         if isinstance(self, UserDict):
-            try:
-                keys_from_both = set(self.keys()) | set(other.keys())
-                return all(Equivalence.__eq__(self[key], other[key]) for key in keys_from_both)
-            except KeyError:
+            if set(self.keys()) != set(other.keys()):
                 return False
+            return all(Equivalence.__eq__(self[key], other[key]) for key in set(self.keys()))
 
         return Equivalence._array_safe_eq(self, other)
 

--- a/eitprocessing/datahandling/mixins/equality.py
+++ b/eitprocessing/datahandling/mixins/equality.py
@@ -28,8 +28,12 @@ class Equivalence:
                 return False
             return all(Equivalence._array_safe_eq(a1, a2) for a1, a2 in zip(t1, t2, strict=True))
 
-        if isinstance(self, UserDict) and isinstance(other, UserDict):
-            return all(Equivalence.__eq__(self[key], other[key]) for key in self)
+        if isinstance(self, UserDict):
+            try:
+                keys_from_both = set(self.keys()) | set(other.keys())
+                return all(Equivalence.__eq__(self[key], other[key]) for key in keys_from_both)
+            except KeyError:
+                return False
 
         return Equivalence._array_safe_eq(self, other)
 

--- a/eitprocessing/datahandling/mixins/equality.py
+++ b/eitprocessing/datahandling/mixins/equality.py
@@ -14,9 +14,10 @@ class Equivalence:
     """Mixin class that adds an equality and equivalence check."""
 
     # inspired by: https://stackoverflow.com/a/51743960/5170442
-    def __eq__(self, other: Self):
+    def __eq__(self, other: Self) -> bool:
         if self is other:
             return True
+
         if is_dataclass(self):
             if self.__class__ is not other.__class__:
                 return NotImplemented
@@ -25,6 +26,10 @@ class Equivalence:
             if len(t1) != len(t2):
                 return False
             return all(Equivalence._array_safe_eq(a1, a2) for a1, a2 in zip(t1, t2, strict=True))
+
+        if isinstance(self, UserDict) and isinstance(other, UserDict):
+            return all(Equivalence.__eq__(self[key], other[key]) for key in self)
+
         return Equivalence._array_safe_eq(self, other)
 
     @staticmethod
@@ -38,9 +43,6 @@ class Equivalence:
 
         if isinstance(a, dict) and isinstance(b, dict):
             return dict.__eq__(a, b)
-
-        if isinstance(a, UserDict) and isinstance(b, UserDict):
-            return dict.__eq__(a.data, b.data)
 
         try:
             # `a == b` could trigger an infinite loop when called on an instance of Equivalence

--- a/eitprocessing/datahandling/mixins/equality.py
+++ b/eitprocessing/datahandling/mixins/equality.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections import UserDict
 from dataclasses import is_dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -37,6 +38,9 @@ class Equivalence:
 
         if isinstance(a, dict) and isinstance(b, dict):
             return dict.__eq__(a, b)
+
+        if isinstance(a, UserDict) and isinstance(b, UserDict):
+            return dict.__eq__(a.data, b.data)
 
         try:
             # `a == b` could trigger an infinite loop when called on an instance of Equivalence
@@ -77,7 +81,7 @@ class Equivalence:
                 raise EquivalenceError(msg)  # noqa: TRY301
 
             # check keys in collection
-            if isinstance(self, dict):
+            if isinstance(self, dict | UserDict):
                 if set(self.keys()) != set(other.keys()):
                     msg = f"Keys don't match:\n\t{self.keys()},\n\t{other.keys()}"
                     raise EquivalenceError(msg)  # noqa: TRY301

--- a/eitprocessing/datahandling/mixins/equality.py
+++ b/eitprocessing/datahandling/mixins/equality.py
@@ -18,9 +18,10 @@ class Equivalence:
         if self is other:
             return True
 
+        if type(self) is not type(other):
+            return False
+
         if is_dataclass(self):
-            if self.__class__ is not other.__class__:
-                return NotImplemented
             t1 = vars(self).values()
             t2 = vars(other).values()
             if len(t1) != len(t2):

--- a/eitprocessing/datahandling/mixins/equality.py
+++ b/eitprocessing/datahandling/mixins/equality.py
@@ -83,6 +83,7 @@ class Equivalence:
                 raise EquivalenceError(msg)  # noqa: TRY301
 
             # check keys in collection
+            # TODO: check whether this is still necessary for dicts #185
             if isinstance(self, dict | UserDict):
                 if set(self.keys()) != set(other.keys()):
                     msg = f"Keys don't match:\n\t{self.keys()},\n\t{other.keys()}"

--- a/eitprocessing/datahandling/sequence.py
+++ b/eitprocessing/datahandling/sequence.py
@@ -77,10 +77,14 @@ class Sequence(Equivalence, SelectByTime, HasTimeIndexer):
         # TODO: rewrite
 
         eit_data = a.eit_data.concatenate(b.eit_data) if a.eit_data and b.eit_data else None
+        continuous_data = (
+            a.continuous_data.concatenate(b.continuous_data) if a.continuous_data and b.continuous_data else None
+        )
+        sparse_data = a.sparse_data.concatenate(b.sparse_data) if a.sparse_data and b.sparse_data else None
 
         # TODO: add concatenation of other attached objects
 
-        return a.__class__(eit_data=eit_data)
+        return a.__class__(eit_data=eit_data, continuous_data=continuous_data, sparse_data=sparse_data)
 
     def _sliced_copy(self, start_index: int, end_index: int, label: str) -> Self:
         eit_data = DataCollection(EITData)


### PR DESCRIPTION
This bug fixes (?) the equality and equivalence checks for DataCollections introduced in #182.

Because the formal tests have not been entirely rewritten this is not extensively tested yet. Equivalence and equality were both tested ad hoc, as well as concatenation of two DataCollections.

Also adds concatenation of Sequence.continuous_data and Sequence.sparse_data (required for testing this). 

I propose merging this now to prevent bugs blocking usage of main.
