### PR TITLE
Add PD011 to ruff ignore list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,7 @@ ignore = [
     "S105",   # Possible hardcoded password
     "S311",   # insecure random generators
     "PT011",  # pytest-raises-too-broad
+    "PD011",  # Use of .values. Assumes .values refers to pandas dataframes, not object attributes
     "TD",     # TODOs
     "FIX002", # Resolve TODOs
     "B028",   # No explicit `stacklevel` keyword argument found in warning


### PR DESCRIPTION
We have multiple objects that have an attribute called values. When addressing that attribute, Ruff assumes it's a pandas dataframe, triggering PD011 (https://docs.astral.sh/ruff/rules/pandas-use-of-dot-values/). 

I'd like to keep using values as the name for te attribute storing values.