### PR TITLE
ci: workflow to run the build of the dashboard

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,9 @@
-name: Python package
+name: Build package
 
 on:
   push:
     branches:
       - main
-      - drcandacemakedamoore/docker
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,33 +44,6 @@ jobs:
             pytest -v ;
             python${{ matrix.python-version }} -m build'
 
-  lint:
-    if: github.event.pull_request.draft == false
-    name: Linting build
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: ["ubuntu-latest"]
-        python-version: ["3.10"]
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python 3.10
-        uses: actions/setup-python@v3
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Python info
-        shell: bash -l {0}
-        run: |
-          which python3
-          python3 --version
-      - name: Upgrade pip and install dependencies
-        run: |
-          python3 -m pip install --upgrade pip setuptools
-          python3 -m pip install .[dev,publishing]
-      - name: Check linting with ruff
-        run: ruff check .
-
   coveralls:
     if: github.event.pull_request.draft == false
     name: Coveralls build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,22 +40,25 @@ jobs:
           ghcr.io/eit-alive/eittestdata:latest
           sh -c 'set -xe ;
             cd /ci ;
-            python -m pip install ".[dev,publishing]" ;
+            python${{ matrix.python-version }} -m pip install ".[dev,publishing]" ;
             pytest -v ;
-            python -m build'
+            python${{ matrix.python-version }} -m build'
 
   lint:
     if: github.event.pull_request.draft == false
     name: Linting build
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
+      matrix:
+        os: ["ubuntu-latest"]
+        python-version: ["3.10"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python 3.10
         uses: actions/setup-python@v3
         with:
-          python-version: "3.10"
+          python-version: ${{ matrix.python-version }}
       - name: Python info
         shell: bash -l {0}
         run: |
@@ -71,9 +74,12 @@ jobs:
   coveralls:
     if: github.event.pull_request.draft == false
     name: Coveralls build
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
+      matrix:
+        os: ["ubuntu-latest"]
+        python-version: ["3.10"]
     steps:
       - uses: actions/checkout@v3
       - name: Connect to Container Registry
@@ -90,12 +96,12 @@ jobs:
           -e EIT_PROCESSING_TEST_DATA=/eitprocessing
           -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           -e COVERALLS_REPO_TOKEN=${{ secrets.COVERALLS_REPO_TOKEN }}
-          -e COVERALLS_FLAG_NAME=python-${{ matrix.version }}
+          -e COVERALLS_FLAG_NAME=python-${{ matrix.python-version }}
           ghcr.io/eit-alive/eittestdata:latest
           sh -c 'set -xe ;
             cd /ci ;
-            python -m pip install --upgrade pip setuptools ;
-            python -m pip install ".[dev,publishing]" ;
+            python${{ matrix.python-version }} -m pip install --upgrade pip setuptools ;
+            python${{ matrix.python-version }} -m pip install ".[dev,publishing]" ;
             pytest --cov --cov-append --cov-report xml --cov-report term --cov-report html ;
             coveralls --service=github ;
-            python -m build'
+            python${{ matrix.python-version }} -m build'

--- a/.github/workflows/cffconvert.yml
+++ b/.github/workflows/cffconvert.yml
@@ -1,16 +1,15 @@
-name: cffconvert
+name: Citation file
 
 on:
   push:
     branches:
-    - main
+      - main
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
-    - main
+      - main
 
 jobs:
-
   verify:
     if: github.event.pull_request.draft == false
     name: "cffconvert"

--- a/.github/workflows/dash_actions.yml
+++ b/.github/workflows/dash_actions.yml
@@ -1,0 +1,22 @@
+name: Dashboard
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths-ignore:
+      - "**.md"
+      - "**.rst"
+      - "**.ipynb"
+    branches:
+      - main
+
+jobs:
+  call-build-workflow:
+    if: github.event.pull_request.draft == false
+    name: Build dashboard
+    uses: EIT-ALIVE/eit_dash/.github/workflows/build.yml@main
+    with:
+      caller_branch: ${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,20 +1,19 @@
-name: documentation
+name: Documentation
 permissions:
   contents: write
 
 on:
   push:
     branches:
-    - main
-    - drcandacemakedamoore/improve_docu
+      - main
+      - drcandacemakedamoore/improve_docu
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
-    - main
-    - drcandacemakedamoore/improve_docu
+      - main
+      - drcandacemakedamoore/improve_docu
 
 jobs:
-
   build-documentation:
     if: github.event.pull_request.draft == false
     name: Build documentation
@@ -26,7 +25,7 @@ jobs:
       - name: Set up Python 3.10
         uses: actions/setup-python@v2
         with:
-          python-version: '3.10'
+          python-version: "3.10"
       - name: Python info
         shell: bash -l {0}
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,41 @@
+name: Linting
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths-ignore:
+      - "**.md"
+      - "**.rst"
+      - "**.ipynb"
+    branches:
+      - main
+
+jobs:
+  lint:
+    if: github.event.pull_request.draft == false
+    name: Linting
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest"]
+        python-version: ["3.10"]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Python info
+        shell: bash -l {0}
+        run: |
+          which python3
+          python3 --version
+      - name: Check linting and formatting using ruff
+        run: |
+          python3 -m pip install ruff
+          ruff check || echo "Please ensure you have the latest version of ruff (`ruff -V`) installed locally."
+          ruff format --check || echo "Please ensure you have the latest version of ruff (`ruff -V`) installed locally."


### PR DESCRIPTION
This PR adds an action to trigger building of the dashboard from the current branch.
This PR should be reviewed in conjunction with [dashboard PR 47](https://github.com/EIT-ALIVE/eit_dash/pull/47)

For nomenclature, i will use _caller_ for the action in this repo and _callee_ for the action in the dashboard.

The following has been checked
- [x] The caller triggers the callee action
  - [x] Once the PR47 in the dashboard is merged, [the main branch should be triggered](https://github.com/EIT-ALIVE/eitprocessing/pull/235#discussion_r1639356324) rather than the PR's branch.
- [x] The callee action is run on the caller's current branch
  - [x] The callee action runs the command to `poetry add` the caller's current branch
  - [x] The caller branch gets added to the callee dependencies
  - [x] The callee dependencies get installed
  - [x] The callee tests run and pass


additional minor changes:
- auto formatting yml files
- build actions use os and python versions as made explicit in matrix

closes #234 