### PR TITLE
ci: temporarily turn off PyPi release upon GitHub release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,9 +2,9 @@ name: Build and upload to PyPI
 
 on:
   workflow_dispatch:
-  release:
-    types:
-      - published
+  # release:
+  #   types:
+  #     - published
 
 jobs:
   build:


### PR DESCRIPTION
Temporary change while working on PR Streamline release process #239.

While testing the action to make a GitHub release, I expect that we will be releasing on GitHub multiple times. We don't want each of these test releases to trigger a PyPi release.
When tests are finished, we can either delete all the GitHub test releases, or do a single new release to PyPi which bypasses all intermediate releases.