### PR TITLE
ci: finalize github release action

### DIFF
--- a/.github/workflows/release_github.yml
+++ b/.github/workflows/release_github.yml
@@ -11,10 +11,6 @@ on:
           - patch
           - minor
           - major
-      release_branch:
-        description: "Branch to use for releasing."
-        type: string
-        default: "develop"
 
 permissions:
   contents: write
@@ -28,6 +24,16 @@ jobs:
         shell: bash -l {0}
 
     steps:
+      - name: Release from develop branch by default
+        if: ${{ github.ref_name }} == 'main'
+        run: |
+          echo "RELEASE_BRANCH=develop" >> $GITHUB_ENV
+
+      - name: Release from specified branch
+        if: ${{ github.ref_name }} != 'main'
+        run: |
+          echo "RELEASE_BRANCH=${{ github.ref_name }}" >> $GITHUB_ENV
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
@@ -42,7 +48,7 @@ jobs:
       - name: Merge changes into main
         run: |
           git switch main
-          git merge ${{ github.event.inputs.release_branch }} --no-ff --no-commit
+          git merge $RELEASE_BRANCH --no-ff --no-commit
           git merge --continue
 
       - name: Bump version
@@ -92,8 +98,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           echo "-- searching for associated PR"
-          branch_name=${{ github.event.inputs.release_branch }}
-          pr_number=$(gh pr list --head $branch_name --json number --jq '.[0].number')
+          pr_number=$(gh pr list --head $RELEASE_BRANCH --json number --jq '.[0].number')
           if [ -n "$pr_number" ]; then
             echo "-- closing PR #$pr_number"
             gh pr close $pr_number
@@ -109,9 +114,9 @@ jobs:
 
       - name: Delete release branch other than main or develop
         run: |
-          if [[ ${{ github.event.inputs.release_branch}} != "main" && ${{ github.event.inputs.release_branch}} != "develop" ]]; then
-            echo "-- deleting branch '${{ github.event.inputs.release_branch }}'"
-            git push origin -d ${{ github.event.inputs.release_branch }}
+          if [[ $RELEASE_BRANCH != "main" && $RELEASE_BRANCH != "develop" ]]; then
+            echo "-- deleting branch '$RELEASE_BRANCH'"
+            git push origin -d $RELEASE_BRANCH
           else
-            echo "-- branch '${{ github.event.inputs.release_branch}}' will not be deleted from remote"
+            echo "-- branch '$RELEASE_BRANCH' will not be deleted from remote"
           fi

--- a/.github/workflows/release_github.yml
+++ b/.github/workflows/release_github.yml
@@ -24,15 +24,11 @@ jobs:
         shell: bash -l {0}
 
     steps:
-      - name: Release from develop branch by default
+      - name: Fail if main branch was selected
         if: ${{ github.ref_name }} == 'main'
         run: |
-          echo "RELEASE_BRANCH=develop" >> $GITHUB_ENV
-
-      - name: Release from specified branch
-        if: ${{ github.ref_name }} != 'main'
-        run: |
-          echo "RELEASE_BRANCH=${{ github.ref_name }}" >> $GITHUB_ENV
+          echo "Cannot release from main branch, please select valid release branch."
+          exit 1
 
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -48,7 +44,7 @@ jobs:
       - name: Merge changes into main
         run: |
           git switch main
-          git merge $RELEASE_BRANCH --no-ff --no-commit
+          git merge ${{ github.ref_name }} --no-ff --no-commit
           git merge --continue
 
       - name: Bump version
@@ -98,7 +94,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           echo "-- searching for associated PR"
-          pr_number=$(gh pr list --head $RELEASE_BRANCH --json number --jq '.[0].number')
+          pr_number=$(gh pr list --head ${{ github.ref_name }} --json number --jq '.[0].number')
           if [ -n "$pr_number" ]; then
             echo "-- closing PR #$pr_number"
             gh pr close $pr_number
@@ -114,9 +110,9 @@ jobs:
 
       - name: Delete release branch other than main or develop
         run: |
-          if [[ $RELEASE_BRANCH != "main" && $RELEASE_BRANCH != "develop" ]]; then
-            echo "-- deleting branch '$RELEASE_BRANCH'"
-            git push origin -d $RELEASE_BRANCH
+          if [[ ${{ github.ref_name }} != "main" && ${{ github.ref_name }} != "develop" ]]; then
+            echo "-- deleting branch '${{ github.ref_name }}'"
+            git push origin -d ${{ github.ref_name }}
           else
-            echo "-- branch '$RELEASE_BRANCH' will not be deleted from remote"
+            echo "-- branch '${{ github.ref_name }}' will not be deleted from remote"
           fi

--- a/.github/workflows/release_github.yml
+++ b/.github/workflows/release_github.yml
@@ -14,7 +14,7 @@ on:
       release_branch:
         description: "Branch to use for releasing."
         type: string
-        default: "test_protected_develop"
+        default: "develop"
 
 permissions:
   contents: write
@@ -41,7 +41,7 @@ jobs:
 
       - name: Merge changes into main
         run: |
-          git switch test_protected_main
+          git switch main
           git merge ${{ github.event.inputs.release_branch }} --no-ff --no-commit
           git merge --continue
 
@@ -103,13 +103,13 @@ jobs:
 
       - name: Merge updates into develop
         run: |
-          git switch test_protected_develop
-          git merge origin/test_protected_main
+          git switch develop
+          git merge origin/main
           git push
 
       - name: Delete release branch other than main or develop
         run: |
-          if [[ ${{ github.event.inputs.release_branch}} != "test_protected_main" && ${{ github.event.inputs.release_branch}} != "test_protected_develop" ]]; then
+          if [[ ${{ github.event.inputs.release_branch}} != "main" && ${{ github.event.inputs.release_branch}} != "develop" ]]; then
             echo "-- deleting branch '${{ github.event.inputs.release_branch }}'"
             git push origin -d ${{ github.event.inputs.release_branch }}
           else

--- a/README.dev.md
+++ b/README.dev.md
@@ -134,13 +134,16 @@ We use [prettier](https://prettier.io/) for formatting most other files. If you 
    - if everything goes well, this PR will automatically be closed after the draft release is created.
 1. Navigate to [Draft Github Release](https://github.com/EIT-ALIVE/eitprocessing/actions/workflows/release_github.yml)
    on the [Actions](https://github.com/EIT-ALIVE/eitprocessing/actions) tab.
-2. On the right hand side, you can select the level increase (patch, minor, or major) and which branch to release from.
-   - if released from a different branch than `develop`, then the workflow will attempt to merge the changes into develop
-     as well. If succesfull, the release branch will be deleted from the remote repository.
-   - [follow semantic versioning conventions](https://semver.org/) to chose the level increase:
+2. On the right hand side, you can select the level increase ("patch", "minor", or "major") and which branch to release from.
+   - [Follow semantic versioning conventions](https://semver.org/) to chose the level increase:
      - `patch`: when backward compatible bug fixes were made
      - `minor`: when functionality was added in a backward compatible manner
      - `major`: when API-incompatible changes have been made
+   - Note that if you choose `main` (the default shown) as the release branch, this will be re-defaulted to develop
+     instead. To release from `main` directly, you must follow the [manual release
+     instructions](#manually-create-a-release) below.
+   - If the release branch is not `develop`, the workflow will attempt to merge the changes into develop as well. If
+     succesfull, the release branch will be deleted from the remote repository.
 3. Visit [Actions](https://github.com/EIT-ALIVE/eitprocessing/actions) tab to check whether everything went as expected.
 4. Navigate to the [Releases](https://github.com/EIT-ALIVE/eitprocessing/releases) tab and click on the newest draft
    release that was just generated.

--- a/README.dev.md
+++ b/README.dev.md
@@ -139,11 +139,10 @@ We use [prettier](https://prettier.io/) for formatting most other files. If you 
      - `patch`: when backward compatible bug fixes were made
      - `minor`: when functionality was added in a backward compatible manner
      - `major`: when API-incompatible changes have been made
-   - Note that if you choose `main` (the default shown) as the release branch, this will be re-defaulted to develop
-     instead. To release from `main` directly, you must follow the [manual release
-     instructions](#manually-create-a-release) below.
    - If the release branch is not `develop`, the workflow will attempt to merge the changes into develop as well. If
      succesfull, the release branch will be deleted from the remote repository.
+   - Note that you cannot release from `main` (the default shown) using the automated workflow. To release from `main`
+     directly, you must [create the release manually](#manually-create-a-release).
 3. Visit [Actions](https://github.com/EIT-ALIVE/eitprocessing/actions) tab to check whether everything went as expected.
 4. Navigate to the [Releases](https://github.com/EIT-ALIVE/eitprocessing/releases) tab and click on the newest draft
    release that was just generated.


### PR DESCRIPTION
- fix branch names to `main` and `develop` instead of `test_protected_XXX`
  - forgot to do this in #242 
- use built-in branch reading system for GitHub actions (see [here](https://github.com/EIT-ALIVE/eitprocessing/actions/workflows/release_github.yml))
  - this is mostly more convenient than the explicit one I wrote
    - because the built-in one cannot be hidden, so would otherwise appear but have no function
    - because the built-in one uses a drop-down menu (with search functionality) of existing branches rather than a string input for the one I wrote
  - the downside is: the default cannot be changed to anything other than `main`, which should never actually be the release branch (the workflow will fail if main is set).


NB: I am also a bit confused now whether this PR should go to main or develop. I think main, so that the action can immediately be used as intended.