### PR TITLE
refactor: derive funcargs dbodor

### DIFF
--- a/eitprocessing/datahandling/continuousdata.py
+++ b/eitprocessing/datahandling/continuousdata.py
@@ -117,7 +117,13 @@ class ContinuousData(Equivalence, SelectByTime):
             derived_from=[*self.derived_from, *other.derived_from, self, other],
         )
 
-    def derive(self, label: str, function: Callable, func_args: dict, **kwargs) -> Self:
+    def derive(
+        self,
+        label: str,
+        function: Callable,
+        func_args: dict | None = None,
+        **kwargs,
+    ) -> Self:
         """Create a copy deriving data from values attribute.
 
         Args:
@@ -146,6 +152,8 @@ class ContinuousData(Equivalence, SelectByTime):
         derived = data.derive("volume_L", convert_data, {"divide": 1000}, name="Lung volume (in L)", unit="L")
         ```
         """
+        if func_args is None:
+            func_args = {}
         copy = self.copy(label, **kwargs)
         copy.values = function(copy.values, **func_args)
         return copy

--- a/eitprocessing/datahandling/continuousdata.py
+++ b/eitprocessing/datahandling/continuousdata.py
@@ -129,8 +129,8 @@ class ContinuousData(Equivalence, SelectByTime):
         Args:
             label: New label for the derived object.
             function: Function that takes the values and returns the derived values.
-            func_args: Arguments to pass to function.
-            **kwargs: New values for attributes of
+            func_args: Arguments to pass to function, if any.
+            **kwargs: Values for changed attributes of derived object.
 
         Example:
         ```


### PR DESCRIPTION
The function used by `derive` does not always require additional arguments, so it would be nice to make the `func_args` argument optional. See e.g. [here](https://github.com/EIT-ALIVE/eitprocessing/blob/demo_notebook_dbodor/notebooks/minidemo.ipynb)