### PR TITLE
Add DataContainer superclass

### DIFF
--- a/eitprocessing/datahandling/__init__.py
+++ b/eitprocessing/datahandling/__init__.py
@@ -1,0 +1,8 @@
+from dataclasses import dataclass
+
+from eitprocessing.datahandling.mixins.equality import Equivalence
+
+
+@dataclass(eq=False)
+class DataContainer(Equivalence):
+    """Base class for data container classes."""

--- a/eitprocessing/datahandling/continuousdata.py
+++ b/eitprocessing/datahandling/continuousdata.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, TypeVar
 
 import numpy as np
 
-from eitprocessing.datahandling.mixins.equality import Equivalence
+from eitprocessing.datahandling import DataContainer
 from eitprocessing.datahandling.mixins.slicing import SelectByTime
 
 if TYPE_CHECKING:
@@ -17,7 +17,7 @@ T = TypeVar("T", bound="ContinuousData")
 
 
 @dataclass(eq=False)
-class ContinuousData(Equivalence, SelectByTime):
+class ContinuousData(DataContainer, SelectByTime):
     """Container for data with a continuous time axis.
 
     Continuous data is assumed to be sequential (i.e. a single data point at each time point, sorted by time) and

--- a/eitprocessing/datahandling/eitdata.py
+++ b/eitprocessing/datahandling/eitdata.py
@@ -9,14 +9,14 @@ import numpy as np
 from strenum import LowercaseStrEnum
 from typing_extensions import Self
 
-from eitprocessing.datahandling.mixins.equality import Equivalence
+from eitprocessing.datahandling import DataContainer
 from eitprocessing.datahandling.mixins.slicing import SelectByTime
 
 T = TypeVar("T", bound="EITData")
 
 
 @dataclass(eq=False)
-class EITData(SelectByTime, Equivalence):
+class EITData(DataContainer, SelectByTime):
     """Container for EIT impedance data.
 
     This class holds the pixel impedance from an EIT measurement, as well as metadata describing the measurement. The

--- a/eitprocessing/datahandling/intervaldata.py
+++ b/eitprocessing/datahandling/intervaldata.py
@@ -5,7 +5,7 @@ from typing import Any, NamedTuple, TypeVar
 import numpy as np
 from typing_extensions import Self
 
-from eitprocessing.datahandling.mixins.equality import Equivalence
+from eitprocessing.datahandling import DataContainer
 from eitprocessing.datahandling.mixins.slicing import HasTimeIndexer, SelectByIndex
 
 T = TypeVar("T", bound="IntervalData")
@@ -19,7 +19,7 @@ class Interval(NamedTuple):
 
 
 @dataclass(eq=False)
-class IntervalData(Equivalence, SelectByIndex, HasTimeIndexer):
+class IntervalData(DataContainer, SelectByIndex, HasTimeIndexer):
     """Container for interval data existing over a period of time.
 
     Interval data is data that consists for a given time interval. Examples are a ventilator setting (e.g.

--- a/eitprocessing/datahandling/sequence.py
+++ b/eitprocessing/datahandling/sequence.py
@@ -8,7 +8,7 @@ from eitprocessing.datahandling.datacollection import DataCollection
 from eitprocessing.datahandling.eitdata import EITData
 from eitprocessing.datahandling.intervaldata import IntervalData
 from eitprocessing.datahandling.mixins.equality import Equivalence
-from eitprocessing.datahandling.mixins.slicing import HasTimeIndexer, SelectByTime
+from eitprocessing.datahandling.mixins.slicing import SelectByTime
 from eitprocessing.datahandling.sparsedata import SparseData
 
 if TYPE_CHECKING:
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 
 
 @dataclass(eq=False)
-class Sequence(Equivalence, SelectByTime, HasTimeIndexer):
+class Sequence(Equivalence, SelectByTime):
     """Sequence of timepoints containing respiratory data.
 
     A Sequence object is a representation of data points over time. These data can consist of any combination of EIT

--- a/eitprocessing/datahandling/sparsedata.py
+++ b/eitprocessing/datahandling/sparsedata.py
@@ -5,14 +5,14 @@ from typing import Any, TypeVar
 import numpy as np
 from typing_extensions import Self
 
-from eitprocessing.datahandling.mixins.equality import Equivalence
+from eitprocessing.datahandling import DataContainer
 from eitprocessing.datahandling.mixins.slicing import SelectByTime
 
 T = TypeVar("T", bound="SparseData")
 
 
 @dataclass(eq=False)
-class SparseData(Equivalence, SelectByTime):
+class SparseData(DataContainer, SelectByTime):
     """Container for data related to individual time points.
 
     Sparse data is data for which the time points are not necessarily evenly spaced. Data can consist time-value pairs


### PR DESCRIPTION
Closes #272.

In this implementation, the superclass is not very functional. It only inherits from Equivalence, removing the requirement therefore from the subclasses.

Ideally, the superclass would take define some common fields (attributes). However, any field (attribute) defined in the superclass would be first in de __init__ function. `label` and `name` have default values in `EITData`, which would not work with non-default fields like `path`. Also, `path` would no longer be the first argument, potentially breaking existing code. To move fields to`DataContainer`, they would have to be the first arguments, or we would have to switch to keyword-only arguments.

This PR also removes superfluous inheritance from Sequence. 