### PR TITLE
refactor: update error when vendor does not exist

### DIFF
--- a/eitprocessing/datahandling/loading/__init__.py
+++ b/eitprocessing/datahandling/loading/__init__.py
@@ -109,9 +109,9 @@ def _check_first_frame(first_frame: int | None) -> int:
 
 
 def _ensure_vendor(vendor: Vendor | str) -> Vendor:
-    """Check whether vendor exists, and assure it's a Vendor object."""
+    """Check whether loading method for vendor exists, and ensure it's a Vendor object."""
     try:
         return Vendor(vendor)
     except ValueError as e:
-        msg = f"Unknown vendor {vendor}."
-        raise ValueError(msg) from e
+        msg = f"No loading method for {vendor} exists."
+        raise NotImplementedError(msg) from e


### PR DESCRIPTION
Assuming that there will be future vendors for which we want to add loading methods, it makes some sense to raise a NotImplementedError here. This indicates (very subtly) to the user that we are planning/willing to add loading methods for it.
It is also in line with the docstring for the loading method.
If we decide to stick to the ValueError (which is equally reasonable), then the docstring should be changed instead to reflect this.