### PR TITLE
Limit ruff version to < 0.6

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -38,6 +38,6 @@ jobs:
           python3 --version
       - name: Check linting and formatting using ruff
         run: |
-          python3 -m pip install ruff
+          python3 -m pip install "ruff < 0.6"
           ruff check || (echo "Please ensure you have the latest ruff (`ruff -V`) installed locally." && (exit 1))
           ruff format --check || (echo "Please ensure you have the latest ruff (`ruff -V`) installed locally." && (exit 1))

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -39,5 +39,5 @@ jobs:
       - name: Check linting and formatting using ruff
         run: |
           python3 -m pip install "ruff < 0.6"
-          ruff check || (echo "Please ensure you have the latest ruff (`ruff -V`) installed locally." && (exit 1))
-          ruff format --check || (echo "Please ensure you have the latest ruff (`ruff -V`) installed locally." && (exit 1))
+          ruff check || (echo "Please ensure you have a matching version of ruff (`ruff -V`) installed locally." && (exit 1))
+          ruff format --check || (echo "Please ensure you have a matching version of ruff (`ruff -V`) installed locally." && (exit 1))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ dependencies = [
     "scipy >= 1.10.1",
     "tqdm >= 4.65.0",
     "strenum >= 0.4.10",
-    "ruff < 0.6",
     "anytree >= 2.12.1 ",
 ]
 
@@ -53,6 +52,7 @@ dev = [
     "sphinx_rtd_theme",
     "sphinx-autoapi",
     "tox",
+    "ruff < 0.6",
     "myst_parser",
 ]
 notebooks = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "scipy >= 1.10.1",
     "tqdm >= 4.65.0",
     "strenum >= 0.4.10",
-    "ruff >= 0.3",
+    "ruff < 0.6",
     "anytree >= 2.12.1 ",
 ]
 
@@ -146,7 +146,7 @@ flake8-tidy-imports.ban-relative-imports = "all" # Disallow all relative imports
 isort.known-first-party = ["eitprocessing"]
 
 [tool.ruff.lint.per-file-ignores]
-"*.ipynb" = ["ERA001"] # Commented out code
+"*.ipynb" = ["ERA001", "T201"] # Commented out code, print() statement
 "tests/*" = [
     "S101",    # Use of `assert` detected
     "ANN201",  # Missing return type


### PR DESCRIPTION
ruff is in not yet mature and updated frequently, sometimes with large changes in linting rules. This often results in code changes in multiple unrelated files mid-PR. This PR fixes the ruff version both in the dev dependencies as the CI linting automation. Therefore, only manual changes to the ruff version will require linting fixes. 

I propose that before or after increasing the version number, someone can decide to increase the ruff version and fix all resulting linting errors, thus removing that responsibility from other developers.