### PR TITLE
Add config data to package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,9 @@ command_line = "-m pytest"
 include = ["eitprocessing*", "eitprocessing.*"]
 exclude = ["tests*", "*tests.*", "*tests"]
 
+[tool.setuptools.package-data]
+eitprocessing = ["config/*.yaml"]
+
 [tool.tox]
 legacy_tox_ini = """
 [tox]


### PR DESCRIPTION
Config data was not packaged with >= 1.4.0. This adds the categories config file to the distributed package.