### PR TITLE
Update Github draft release workflow

### DIFF
--- a/.github/actions/install_eitprocessing/action.yml
+++ b/.github/actions/install_eitprocessing/action.yml
@@ -45,5 +45,5 @@ runs:
         key: ${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml') }}-[${{ inputs.dependencies }}]
     - name: Install eitprocessing with [${{ inputs.dependencies }}] dependencies
       if: steps.cache-python-env.outputs.cache-hit != 'true'
-      run: python3 -m pip install -e ".[${{ inputs.dependencies }}]"
+      run: python3 -m pip install ".[${{ inputs.dependencies }}]"
       shell: bash

--- a/.github/workflows/release_github.yml
+++ b/.github/workflows/release_github.yml
@@ -90,7 +90,7 @@ jobs:
           fetch-depth: 0
       - name: Configure git
         run: |
-          git config --global user.email "${GITHUB_ACTOR_ID}+${GITHUB_ACTOR}@users.noreply.github.com"
+          git config user.email "${GITHUB_ACTOR_ID}+${GITHUB_ACTOR}@users.noreply.github.com"
           git config user.name "GitHub Actions"
           git config -l
       - name: Merge changes into main

--- a/.github/workflows/release_github.yml
+++ b/.github/workflows/release_github.yml
@@ -38,25 +38,20 @@ jobs:
           exit 1
 
       - name: Checkout repository
-        if: ${{ github.ref_name != 'develop' }}
         uses: actions/checkout@v4
 
       - name: Check if PR exists
-        if: ${{ github.ref_name != 'develop' }}
         run: gh pr view ${{ github.ref_name }}
 
       - name: Check if PR base is main
-        if: ${{ github.ref_name != 'develop' }}
         run: gh pr view ${{ github.ref_name }} --json baseRefName -q 'if .baseRefName == "main" then "PR base is main" else error("PR base is not main") end'
 
       - name: Check if PR is mergeable
-        if: ${{ github.ref_name != 'develop' }}
         run: gh pr view ${{ github.ref_name }} --json mergeable -q 'if .mergeable == "MERGEABLE" then "PR is mergeable" else error("PR is not mergeable") end'
 
       - name: Check whether PR checks pass(ed)
         # note that this assumed there are checks to be passed; this fails if there are no checks, which is no
         # relevant to this repo
-        if: ${{ github.ref_name != 'develop' }}
         run: |
           gh pr checks ${{ github.ref_name }} --watch --fail-fast
           gh pr checks ${{ github.ref_name }} --json state -q 'if . | length == 0 then "No checks found." elif map(.state == "SUCCESS") | all then "All checks passed" else error("Not all checks passed") end'

--- a/.github/workflows/release_github.yml
+++ b/.github/workflows/release_github.yml
@@ -12,7 +12,7 @@ on:
           - patch
           - minor
           - major
-          
+
 permissions:
   contents: write
   packages: read
@@ -29,7 +29,7 @@ env:
 jobs:
   checks:
     name: Check requirements
-    runs-on: "ubuntu-latest"
+    runs-on: ubuntu-latest
     steps:
       - name: Fail if main branch was selected
         if: ${{ github.ref_name == 'main' }}
@@ -48,7 +48,7 @@ jobs:
       - name: Check if PR base is main
         if: ${{ github.ref_name != 'develop' }}
         run: gh pr view ${{ github.ref_name }} --json baseRefName -q 'if .baseRefName == "main" then "PR base is main" else error("PR base is not main") end'
-        
+
       - name: Check if PR is mergeable
         if: ${{ github.ref_name != 'develop' }}
         run: gh pr view ${{ github.ref_name }} --json mergeable -q 'if .mergeable == "MERGEABLE" then "PR is mergeable" else error("PR is not mergeable") end'
@@ -59,7 +59,7 @@ jobs:
         if: ${{ github.ref_name != 'develop' }}
         run: |
           gh pr checks ${{ github.ref_name }} --watch --fail-fast
-          gh pr checks ${{ github.ref_name }} --json state -q 'if . | length == 0 then "No checks found." elif map(.state == "SUCCESS") | all then "All checks passed" else error("Not all checks passed") end'            
+          gh pr checks ${{ github.ref_name }} --json state -q 'if . | length == 0 then "No checks found." elif map(.state == "SUCCESS") | all then "All checks passed" else error("Not all checks passed") end'
 
   test_python_releases:
     needs: checks
@@ -90,7 +90,7 @@ jobs:
       - name: Build eitprocessing
         run: python3 -m build
 
-  merge_and_bump: 
+  merge_and_bump:
     name: Merge the changes into main and bump the version
     needs: test_python_releases
     runs-on: ubuntu-latest
@@ -113,18 +113,18 @@ jobs:
       - name: Merge branch into main
         run: |
           git switch main
-          git branch -f ${{ github.ref_name }} origin/${{ github.ref_name }} 
+          git branch -f ${{ github.ref_name }} origin/${{ github.ref_name }}
           git merge ${{ github.ref_name }} --no-ff --no-edit
-    
+
       - name: Install Python
         uses: actions/setup-python@v5.1.1
         with:
-          python-version: '3.12'
-  
+          python-version: "3.12"
+
       - name: Install bump-my-version
         shell: bash
         run: pip install "bump-my-version==0.28.1"
-        
+
       - name: Pass Inputs to Shell
         id: bump
         shell: bash
@@ -148,7 +148,7 @@ jobs:
         run: |
           git checkout develop
           git merge main --no-ff --no-edit
-      
+
       - name: Push changes to GitHub
         uses: ad-m/github-push-action@master
         with:
@@ -164,11 +164,11 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: main
-  
+
   github_release:
     name: Create a draft GitHub release
     needs: merge_and_bump
-    runs-on: 'ubuntu-latest'
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -195,7 +195,7 @@ jobs:
         with:
           ref: develop
           fetch-depth: 0
-      
+
       - name: Remove PR branch
         if: ${{ github.ref_name != 'develop' }}
         uses: dawidd6/action-delete-branch@v3

--- a/.github/workflows/release_github.yml
+++ b/.github/workflows/release_github.yml
@@ -3,10 +3,11 @@ name: Draft GitHub Release
 on:
   workflow_dispatch:
     inputs:
-      version_level:
-        description: "Semantic version level increase."
+      version_level: 
+        description: Semantic version level increase
         required: true
         type: choice
+        default: patch
         options:
           - patch
           - minor
@@ -14,11 +15,26 @@ on:
 
 permissions:
   contents: write
-  pull-requests: write
   packages: read
+  statuses: read
+  checks: read
+  pull-requests: write
+  actions: read
+  repository-projects: read
 
 jobs:
+  check_main:
+    name: Check that branch is not main
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Fail if main branch was selected
+        if: ${{ github.ref_name == 'main' }}
+        run: |
+          echo "Cannot release from main branch, please select valid release branch."
+          exit 1
+
   test_python_releases:
+    needs: check_main
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -43,83 +59,138 @@ jobs:
         run: python3 -m pip install --upgrade ".[publishing]"
       - name: Build eitprocessing
         run: python3 -m build
-  
+    
 
-  github_release:
+  merge_pr:
+    name: Merge the PR into main
+    if: ${{ github.ref_name != 'develop' }}
     needs: test_python_releases
-    runs-on: "ubuntu-latest"
-    defaults:
-      run:
-        shell: bash -l {0}
-
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - name: Fail if main branch was selected
-        if: ${{ github.ref_name == 'main' }}
-        run: |
-          echo "Cannot release from main branch, please select valid release branch."
-          exit 1
+      - name: Checkout the code
+        uses: actions/checkout@v4
 
+      - name: Set PR base to main and merge
+        run: |
+          gh pr edit ${{ github.ref_name }} --base main
+          gh pr merge ${{ github.ref_name }} --merge --admin
+    
+  merge_develop:
+    name: Merge develop into main
+    if: ${{ github.ref_name == 'develop'}}
+    needs: test_python_releases
+    runs-on: ubuntu-latest
+    steps: 
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GH_PAT }}
           ref: main
           fetch-depth: 0
 
       - name: Configure git
         run: |
-          git config user.email "actions@github.com"
+          git config --global user.email "${GITHUB_ACTOR_ID}+${GITHUB_ACTOR}@users.noreply.github.com"
           git config user.name "GitHub Actions"
-          git pull
+          git config -l
 
       - name: Merge changes into main
         run: |
           git switch main
           git branch ${{ github.ref_name }} origin/${{ github.ref_name }} 
-          git merge ${{ github.ref_name }} --no-ff --no-commit
-          git commit --no-edit
+          git merge ${{ github.ref_name }} --no-ff --no-edit
+      
+      - name: Push changes to GitHub
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          force: true
 
-      - name: Bump version
-        id: bump
+  bump_version:
+    name: Bump the version
+    needs: [merge_pr, merge_develop]
+    if: ${{ always() && (needs.merge_pr.result == 'success' || needs.merge_develop.result == 'success') }}
+    runs-on: 'ubuntu-latest'
+    outputs:
+      new-version: ${{ steps.bump.outputs.current-version }}
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v4
+        with:
+          ref: main
+      - name: Setting up git config
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "-- install bump-my-version"
-          python3 -m pip install bump-my-version
-          echo "-- bump the version"
-          bump-my-version bump ${{ github.event.inputs.version_level }} --commit --tag
-          echo "-- push bumped version"
-          echo "RELEASE_TAG=$(git describe --tags --abbrev=0)" >> $GITHUB_OUTPUT
-          git push --tags -f
-          git push
+          git config --global user.email "${GITHUB_ACTOR_ID}+${GITHUB_ACTOR}@users.noreply.github.com"
+          git config user.name "GitHub Actions"
+          git config -l
+      - name: Install Python
+        uses: actions/setup-python@v5.1.1
+        with:
+          python-version: '3.12'
+      - name: Install bump-my-version
+        shell: bash
+        run: pip install "bump-my-version==0.28.1"
+      - name: Pass Inputs to Shell
+        id: bump
+        shell: bash
+        run: |
+          echo "previous-version=$(bump-my-version show current_version)" >> $GITHUB_OUTPUT
+          bump-my-version bump ${{ inputs.version_level }} --commit --tag
+          ([[ $? -gt 0 ]] && echo "bumped=false" || echo "bumped=true") >> $GITHUB_OUTPUT
+          echo "current-version=$(bump-my-version show current_version)" >> $GITHUB_OUTPUT
+      - name: Push changes to GitHub
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          force: true
+
+      - name: Fail if bumping failes
+        if: steps.bump.outputs.bumped == 'false'
+        run: |
+          echo "Bumping failed."
+          exit 1
+
+      - name: Check new version number
+        if: steps.bump.outputs.bumped == 'true'
+        run: |
+          echo "Version was bumped from ${{ steps.bump.outputs.previous-version }} to ${{ steps.bump.outputs.current-version }}!"
+  
+  github_release:
+    name: Create a draft GitHub release
+    needs: bump_version
+    if: ${{ always() && needs.bump_version.result == 'success' }}
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v4
+        with:
+          ref: main
 
       - name: Create GitHub Release
         id: create_release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create ${{ steps.bump.outputs.RELEASE_TAG }} \
-              --title="Release ${{ steps.bump.outputs.RELEASE_TAG }}" \
+          gh release create v${{ needs.bump_version.outputs.new-version }} \
+              --title="Release v${{ needs.bump_version.outputs.new-version }}" \
               --generate-notes \
               --draft
 
-      - name: Validate CITATION.cff
-        id: validate_cff
-        env:
-          GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-        uses: dieghernan/cff-validator@v3
-
   tidy_workspace:
-    # only run if action above succeeds
+    name: Tidy up the repository
     needs: github_release
-    runs-on: "ubuntu-latest"
-    defaults:
-      run:
-        shell: bash -l {0}
+    if: ${{ always() && needs.github_release.result == 'success' }}
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GH_PAT }}
+          ref: develop
           fetch-depth: 0
 
       - name: Configure git
@@ -128,30 +199,15 @@ jobs:
           git config user.name "GitHub Actions"
           git pull
 
-      - name: Close PR
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Merge main into develop
         run: |
-          echo "-- searching for associated PR"
-          pr_number=$(gh pr list --head ${{ github.ref_name }} --json number --jq '.[0].number')
-          if [ -n "$pr_number" ]; then
-            echo "-- closing PR #$pr_number"
-            gh pr close $pr_number
-          else
-            echo "-- no open pull request found for branch $branch_name"
-          fi
-
-      - name: Merge updates into develop
-        run: |
-          git switch develop
-          git merge --no-ff origin/main
+          git branch main origin/main
+          git merge main --no-ff --no-edit
           git push
-
-      - name: Delete release branch other than main or develop
-        run: |
-          if [[ ${{ github.ref_name }} != "main" && ${{ github.ref_name }} != "develop" ]]; then
-            echo "-- deleting branch '${{ github.ref_name }}'"
-            git push origin -d ${{ github.ref_name }}
-          else
-            echo "-- branch '${{ github.ref_name }}' will not be deleted from remote"
-          fi
+      
+      - name: Remove PR branch
+        if: ${{ github.ref_name != 'develop' }}
+        uses: dawidd6/action-delete-branch@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branches: ${{ github.ref_name }}

--- a/.github/workflows/release_github.yml
+++ b/.github/workflows/release_github.yml
@@ -194,10 +194,10 @@ jobs:
               --generate-notes \
               --draft
 
-  tidy_workspace:
-    name: Tidy up the repository
+  remove_branch:
+    name: Remove PR branch
     needs: github_release
-    if: ${{ always() && needs.github_release.result == 'success' }}
+    if: ${{ github.ref_name != 'develop' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -207,7 +207,6 @@ jobs:
           fetch-depth: 0
 
       - name: Remove PR branch
-        if: ${{ github.ref_name != 'develop' }}
         uses: dawidd6/action-delete-branch@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release_github.yml
+++ b/.github/workflows/release_github.yml
@@ -12,7 +12,7 @@ on:
           - patch
           - minor
           - major
-
+          
 permissions:
   contents: write
   packages: read
@@ -22,9 +22,13 @@ permissions:
   actions: read
   repository-projects: read
 
+env:
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  GH_PAGER: cat
+
 jobs:
-  check_main:
-    name: Check that branch is not main
+  checks:
+    name: Check requirements
     runs-on: "ubuntu-latest"
     steps:
       - name: Fail if main branch was selected
@@ -33,8 +37,32 @@ jobs:
           echo "Cannot release from main branch, please select valid release branch."
           exit 1
 
+      - name: Checkout repository
+        if: ${{ github.ref_name != 'develop' }}
+        uses: actions/checkout@v4
+
+      - name: Check if PR exists
+        if: ${{ github.ref_name != 'develop' }}
+        run: gh pr view ${{ github.ref_name }}
+
+      - name: Check if PR base is main
+        if: ${{ github.ref_name != 'develop' }}
+        run: gh pr view ${{ github.ref_name }} --json baseRefName -q 'if .baseRefName == "main" then "PR base is main" else error("PR base is not main") end'
+        
+      - name: Check if PR is mergeable
+        if: ${{ github.ref_name != 'develop' }}
+        run: gh pr view ${{ github.ref_name }} --json mergeable -q 'if .mergeable == "MERGEABLE" then "PR is mergeable" else error("PR is not mergeable") end'
+
+      - name: Check whether PR checks pass(ed)
+        # note that this assumed there are checks to be passed; this fails if there are no checks, which is no
+        # relevant to this repo
+        if: ${{ github.ref_name != 'develop' }}
+        run: |
+          gh pr checks ${{ github.ref_name }} --watch --fail-fast
+          gh pr checks ${{ github.ref_name }} --json state -q 'if . | length == 0 then "No checks found." elif map(.state == "SUCCESS") | all then "All checks passed" else error("Not all checks passed") end'            
+
   test_python_releases:
-    needs: check_main
+    needs: checks
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -62,26 +90,14 @@ jobs:
       - name: Build eitprocessing
         run: python3 -m build
 
-  merge_pr:
-    name: Merge the PR into main
-    if: ${{ github.ref_name != 'develop' }}
+  merge_and_bump: 
+    name: Merge the changes into main and bump the version
     needs: test_python_releases
     runs-on: ubuntu-latest
+    outputs:
+      new-version: ${{ steps.bump.outputs.current-version }}
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      - name: Set PR base to main and merge
-        run: |
-          gh pr edit ${{ github.ref_name }} --base main
-          gh pr merge ${{ github.ref_name }} --merge --admin
-
-  merge_develop:
-    name: Merge develop into main
-    if: ${{ github.ref_name == 'develop'}}
-    needs: test_python_releases
-    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -93,44 +109,22 @@ jobs:
           git config user.email "${GITHUB_ACTOR_ID}+${GITHUB_ACTOR}@users.noreply.github.com"
           git config user.name "GitHub Actions"
           git config -l
-      - name: Merge changes into main
+
+      - name: Merge branch into main
         run: |
           git switch main
-          git branch ${{ github.ref_name }} origin/${{ github.ref_name }} 
+          git branch -f ${{ github.ref_name }} origin/${{ github.ref_name }} 
           git merge ${{ github.ref_name }} --no-ff --no-edit
-      - name: Push changes to GitHub
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          force: true
-
-  bump_version:
-    name: Bump the version
-    needs: [merge_pr, merge_develop]
-    if: ${{ always() && (needs.merge_pr.result == 'success' || needs.merge_develop.result == 'success') }}
-    runs-on: "ubuntu-latest"
-    outputs:
-      new-version: ${{ steps.bump.outputs.current-version }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          ref: main
-      - name: Setting up git config
-        shell: bash
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git config --global user.email "${GITHUB_ACTOR_ID}+${GITHUB_ACTOR}@users.noreply.github.com"
-          git config user.name "GitHub Actions"
-          git config -l
+    
       - name: Install Python
         uses: actions/setup-python@v5.1.1
         with:
-          python-version: "3.12"
+          python-version: '3.12'
+  
       - name: Install bump-my-version
         shell: bash
         run: pip install "bump-my-version==0.28.1"
+        
       - name: Pass Inputs to Shell
         id: bump
         shell: bash
@@ -139,26 +133,42 @@ jobs:
           bump-my-version bump ${{ inputs.version_level }} --commit --tag
           ([[ $? -gt 0 ]] && echo "bumped=false" || echo "bumped=true") >> $GITHUB_OUTPUT
           echo "current-version=$(bump-my-version show current_version)" >> $GITHUB_OUTPUT
-      - name: Push changes to GitHub
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          force: true
       - name: Fail if bumping failes
         if: steps.bump.outputs.bumped == 'false'
         run: |
           echo "Bumping failed."
+          git reset --hard HEAD^
           exit 1
       - name: Check new version number
         if: steps.bump.outputs.bumped == 'true'
         run: |
           echo "Version was bumped from ${{ steps.bump.outputs.previous-version }} to ${{ steps.bump.outputs.current-version }}!"
 
+      - name: Merge main into develop
+        run: |
+          git checkout develop
+          git merge main --no-ff --no-edit
+      
+      - name: Push changes to GitHub
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: develop
+
+      - name: Checkout main
+        run: |
+          git checkout main
+
+      - name: Push changes to GitHub
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: main
+  
   github_release:
     name: Create a draft GitHub release
-    needs: bump_version
-    if: ${{ always() && needs.bump_version.result == 'success' }}
-    runs-on: "ubuntu-latest"
+    needs: merge_and_bump
+    runs-on: 'ubuntu-latest'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -169,8 +179,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create v${{ needs.bump_version.outputs.new-version }} \
-              --title="Release v${{ needs.bump_version.outputs.new-version }}" \
+          gh release create v${{ needs.merge_and_bump.outputs.new-version }} \
+              --title="Release v${{ needs.merge_and_bump.outputs.new-version }}" \
               --generate-notes \
               --draft
 
@@ -185,16 +195,7 @@ jobs:
         with:
           ref: develop
           fetch-depth: 0
-      - name: Configure git
-        run: |
-          git config user.email "actions@github.com"
-          git config user.name "GitHub Actions"
-          git pull
-      - name: Merge main into develop
-        run: |
-          git branch main origin/main
-          git merge main --no-ff --no-edit
-          git push
+      
       - name: Remove PR branch
         if: ${{ github.ref_name != 'develop' }}
         uses: dawidd6/action-delete-branch@v3

--- a/.github/workflows/release_github.yml
+++ b/.github/workflows/release_github.yml
@@ -75,6 +75,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
       - name: Install eitprocessing
         uses: ./.github/actions/install_eitprocessing
         with:
@@ -83,10 +84,13 @@ jobs:
           python-version: ${{ matrix.python-version }}
           token: ${{ secrets.GITHUB_TOKEN }}
           data-directory: ${{ env.EIT_PROCESSING_TEST_DATA }}
+
       - name: Run pytest
         run: pytest -v
+
       - name: Install additional dependencies for building
         run: python3 -m pip install --upgrade ".[publishing]"
+
       - name: Build eitprocessing
         run: python3 -m build
 
@@ -104,6 +108,7 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
+
       - name: Configure git
         run: |
           git config user.email "${GITHUB_ACTOR_ID}+${GITHUB_ACTOR}@users.noreply.github.com"
@@ -135,12 +140,14 @@ jobs:
           bump-my-version bump ${{ inputs.version_level }} --commit --tag
           ([[ $? -gt 0 ]] && echo "bumped=false" || echo "bumped=true") >> $GITHUB_OUTPUT
           echo "current-version=$(bump-my-version show current_version)" >> $GITHUB_OUTPUT
+
       - name: Fail if bumping failes
         if: steps.bump.outputs.bumped == 'false'
         run: |
           echo "Bumping failed."
           git reset --hard HEAD^
           exit 1
+
       - name: Check new version number
         if: steps.bump.outputs.bumped == 'true'
         run: |
@@ -151,7 +158,7 @@ jobs:
           git checkout develop
           git merge main --no-ff --no-edit
 
-      - name: Push changes to GitHub
+      - name: Push changes to develop
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -161,7 +168,7 @@ jobs:
         run: |
           git checkout main
 
-      - name: Push changes to GitHub
+      - name: Push changes to main
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -176,6 +183,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: main
+
       - name: Create GitHub Release
         id: create_release
         env:

--- a/.github/workflows/release_github.yml
+++ b/.github/workflows/release_github.yml
@@ -3,7 +3,7 @@ name: Draft GitHub Release
 on:
   workflow_dispatch:
     inputs:
-      version_level: 
+      version_level:
         description: Semantic version level increase
         required: true
         type: choice
@@ -38,15 +38,17 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
-      matrix: 
+      matrix:
         os: ["ubuntu-latest"]
         python-version: ["3.10", "3.11", "3.12", "3.13"]
     name: Build for ${{ matrix.python-version }}, ${{ matrix.os }}
-    env: 
+    env:
       EIT_PROCESSING_TEST_DATA: ${{ github.workspace }}/../eitprocessing_data/
     steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/install_eitprocessing
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Install eitprocessing
+        uses: ./.github/actions/install_eitprocessing
         with:
           dependencies: testing
           extract-data: true
@@ -55,11 +57,10 @@ jobs:
           data-directory: ${{ env.EIT_PROCESSING_TEST_DATA }}
       - name: Run pytest
         run: pytest -v
-      - name: Install eitprocessing with dev dependencies
+      - name: Install additional dependencies for building
         run: python3 -m pip install --upgrade ".[publishing]"
       - name: Build eitprocessing
         run: python3 -m build
-    
 
   merge_pr:
     name: Merge the PR into main
@@ -69,38 +70,34 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - name: Checkout the code
+      - name: Checkout repository
         uses: actions/checkout@v4
-
       - name: Set PR base to main and merge
         run: |
           gh pr edit ${{ github.ref_name }} --base main
           gh pr merge ${{ github.ref_name }} --merge --admin
-    
+
   merge_develop:
     name: Merge develop into main
     if: ${{ github.ref_name == 'develop'}}
     needs: test_python_releases
     runs-on: ubuntu-latest
-    steps: 
+    steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           ref: main
           fetch-depth: 0
-
       - name: Configure git
         run: |
           git config --global user.email "${GITHUB_ACTOR_ID}+${GITHUB_ACTOR}@users.noreply.github.com"
           git config user.name "GitHub Actions"
           git config -l
-
       - name: Merge changes into main
         run: |
           git switch main
           git branch ${{ github.ref_name }} origin/${{ github.ref_name }} 
           git merge ${{ github.ref_name }} --no-ff --no-edit
-      
       - name: Push changes to GitHub
         uses: ad-m/github-push-action@master
         with:
@@ -111,11 +108,11 @@ jobs:
     name: Bump the version
     needs: [merge_pr, merge_develop]
     if: ${{ always() && (needs.merge_pr.result == 'success' || needs.merge_develop.result == 'success') }}
-    runs-on: 'ubuntu-latest'
+    runs-on: "ubuntu-latest"
     outputs:
       new-version: ${{ steps.bump.outputs.current-version }}
     steps:
-      - name: Checkout the code
+      - name: Checkout repository
         uses: actions/checkout@v4
         with:
           ref: main
@@ -130,7 +127,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v5.1.1
         with:
-          python-version: '3.12'
+          python-version: "3.12"
       - name: Install bump-my-version
         shell: bash
         run: pip install "bump-my-version==0.28.1"
@@ -147,29 +144,26 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           force: true
-
       - name: Fail if bumping failes
         if: steps.bump.outputs.bumped == 'false'
         run: |
           echo "Bumping failed."
           exit 1
-
       - name: Check new version number
         if: steps.bump.outputs.bumped == 'true'
         run: |
           echo "Version was bumped from ${{ steps.bump.outputs.previous-version }} to ${{ steps.bump.outputs.current-version }}!"
-  
+
   github_release:
     name: Create a draft GitHub release
     needs: bump_version
     if: ${{ always() && needs.bump_version.result == 'success' }}
-    runs-on: 'ubuntu-latest'
+    runs-on: "ubuntu-latest"
     steps:
-      - name: Checkout the code
+      - name: Checkout repository
         uses: actions/checkout@v4
         with:
           ref: main
-
       - name: Create GitHub Release
         id: create_release
         env:
@@ -185,26 +179,22 @@ jobs:
     needs: github_release
     if: ${{ always() && needs.github_release.result == 'success' }}
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           ref: develop
           fetch-depth: 0
-
       - name: Configure git
         run: |
           git config user.email "actions@github.com"
           git config user.name "GitHub Actions"
           git pull
-
       - name: Merge main into develop
         run: |
           git branch main origin/main
           git merge main --no-ff --no-edit
           git push
-      
       - name: Remove PR branch
         if: ${{ github.ref_name != 'develop' }}
         uses: dawidd6/action-delete-branch@v3

--- a/.github/workflows/release_github.yml
+++ b/.github/workflows/release_github.yml
@@ -151,7 +151,7 @@ jobs:
       - name: Merge main into develop
         run: |
           git checkout develop
-          git merge main --no-ff --no-edit
+          git merge main --no-ff --no-edit || { echo "Can't merge changes to develop. Manually merge PR and create GitHub release."; exit 1; }
 
       - name: Push changes to develop
         uses: ad-m/github-push-action@master

--- a/.github/workflows/release_github.yml
+++ b/.github/workflows/release_github.yml
@@ -123,7 +123,9 @@ jobs:
 
       - name: Install bump-my-version
         shell: bash
-        run: pip install "bump-my-version==0.28.1"
+        run: |
+          python3 -m pip install pyproject-deplister
+          pyproject-deplister --extra dev --path pyproject.toml | grep bump-my-version | sed 's/ //g' | xargs -I{} python3 -m pip install "{}"
 
       - name: Pass Inputs to Shell
         id: bump

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -26,6 +26,7 @@
   "rewrap.wrappingColumn": 120,
   "rewrap.autoWrap.enabled": true,
   "editor.formatOnSave": true,
+  "files.trimTrailingWhitespace": true,
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "[ignore]": {
     "editor.defaultFormatter": "foxundermoon.shell-format"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
 # development dependency groups
 dev = [
     "pytest >= 7.4.0",
-    "bump-my-version",
+    "bump-my-version==0.28.1",
     "coverage",
     "pytest-cov",
     "coveralls",


### PR DESCRIPTION
This PR was extensively tested in a separate repo. This workflow update cleans up the workflow and more clearly splits merging a PR from merging develop. The main improvement is explicitly closing a PR using the gh CLI.

This supports either creating a release from develop -> main or from a branch associated with a PR -> main. If you select a branch with no PR associated, the merge PR job will fail.