### PR TITLE
Detect sample frequency for Draeger data

### DIFF
--- a/eitprocessing/datahandling/loading/__init__.py
+++ b/eitprocessing/datahandling/loading/__init__.py
@@ -33,7 +33,7 @@ def load_eit_data(
             Defaults to the same value as label.
         description: long description of sequence for human interpretation.
         sample_frequency: sample frequency at which the data was recorded.
-            Default for Draeger: 20
+            No default for Draeger. Will be autodetected. Warns if autodetected differs from provided.
             Default for Timpel: 50
             Default for Sentec: 50.2
         first_frame: index of first frame to load.
@@ -67,10 +67,6 @@ def load_eit_data(
         Vendor.TIMPEL: timpel.load_from_single_path,
         Vendor.SENTEC: sentec.load_from_single_path,
     }[vendor]
-
-    if vendor == Vendor.DRAEGER and not sample_frequency:
-        msg = """Provide a sample frequency when loading Draeger data."""
-        raise NotImplementedError(msg)  # automatic sample frequency detection is to be implemented per #217
 
     first_frame = _check_first_frame(first_frame)
 

--- a/eitprocessing/datahandling/loading/draeger.py
+++ b/eitprocessing/datahandling/loading/draeger.py
@@ -94,7 +94,10 @@ def load_from_single_path(
         sample_frequency = estimated_sample_frequency
 
     if sample_frequency != estimated_sample_frequency:
-        msg = "Provided sample frequency {} does not match the estimated sample frequency."
+        msg = (
+            f"Provided sample frequency ({sample_frequency}) does not match "
+            f"the estimated sample frequency ({estimated_sample_frequency})."
+        )
         warnings.warn(msg, RuntimeWarning)
 
     # time wraps around the number of seconds in a day

--- a/eitprocessing/datahandling/loading/draeger.py
+++ b/eitprocessing/datahandling/loading/draeger.py
@@ -88,7 +88,7 @@ def load_from_single_path(
                 previous_marker,
             )
 
-    estimated_sample_frequency = round((len(time) - 1) / (time[-1] - time[0]), 6)
+    estimated_sample_frequency = round((len(time) - 1) / (time[-1] - time[0]), 4)
 
     if not sample_frequency:
         sample_frequency = estimated_sample_frequency

--- a/eitprocessing/datahandling/loading/draeger.py
+++ b/eitprocessing/datahandling/loading/draeger.py
@@ -28,7 +28,7 @@ load_draeger_data = partial(load_eit_data, vendor=Vendor.DRAEGER)
 
 def load_from_single_path(
     path: Path,
-    sample_frequency: float,
+    sample_frequency: float | None = None,
     first_frame: int = 0,
     max_frames: int | None = None,
 ) -> dict[str, DataCollection]:

--- a/eitprocessing/datahandling/loading/draeger.py
+++ b/eitprocessing/datahandling/loading/draeger.py
@@ -88,9 +88,14 @@ def load_from_single_path(
                 previous_marker,
             )
 
+    estimated_sample_frequency = round((len(time) - 1) / (time[-1] - time[0]), 6)
+
     if not sample_frequency:
-        msg = "No sample frequency provided. "
-        raise ValueError(msg)
+        sample_frequency = estimated_sample_frequency
+
+    if sample_frequency != estimated_sample_frequency:
+        msg = "Provided sample frequency {} does not match the estimated sample frequency."
+        warnings.warn(msg, RuntimeWarning)
 
     # time wraps around the number of seconds in a day
     time = np.unwrap(time, period=24 * 60 * 60)

--- a/tests/test_loading.py
+++ b/tests/test_loading.py
@@ -41,6 +41,15 @@ def test_loading_draeger(
     # assert draeger_both != draeger_inverted
 
 
+def test_sample_frequency_draeger():
+    with_sf = load_eit_data(draeger_file1, vendor="draeger", sample_frequency=20)
+    without_sf = load_eit_data(draeger_file1, vendor="draeger")
+    assert with_sf.eit_data["raw"].sample_frequency == without_sf.eit_data["raw"].sample_frequency
+
+    with pytest.warns(RuntimeWarning):
+        _ = load_eit_data(draeger_file1, vendor="draeger", sample_frequency=50)
+
+
 def test_loading_timpel(
     draeger1: Sequence,
     timpel1: Sequence,
@@ -68,10 +77,6 @@ def test_loading_illegal():
         _ = load_eit_data(draeger_file1, vendor="timpel")
     with pytest.raises(OSError):
         _ = load_eit_data(timpel_file, vendor="draeger", sample_frequency=20)
-
-    # no sample frequency provided
-    with pytest.raises(NotImplementedError):
-        _ = load_eit_data(timpel_file, vendor="draeger", sample_frequency=None)
 
 
 def test_load_partial(


### PR DESCRIPTION
Closes #217

In this PR, the sample frequency of Draeger data is estimated from the time axis in the data. If a sample frequency is provided during loading, this is used, but a difference between the estimated and provided frequency results in a warning. This unfortunately makes loading between manufacturers inconsistent, but we can work around that.