### PR TITLE
Add data access object to sequences

### DIFF
--- a/eitprocessing/datahandling/__init__.py
+++ b/eitprocessing/datahandling/__init__.py
@@ -10,6 +10,9 @@ from eitprocessing.datahandling.mixins.equality import Equivalence
 class DataContainer(Equivalence):
     """Base class for data container classes."""
 
+    def __bool__(self):
+        return True
+
     def deepcopy(self) -> Self:
         """Return a deep copy of the object."""
         return deepcopy(self)

--- a/eitprocessing/datahandling/mixins/slicing.py
+++ b/eitprocessing/datahandling/mixins/slicing.py
@@ -62,7 +62,7 @@ class SelectByIndex(ABC):
         return self._sliced_copy(start_index=start, end_index=end, newlabel=newlabel)
 
     @abstractmethod
-    def __len__(self): ...
+    def __len__(self) -> int: ...
 
     @abstractmethod
     def _sliced_copy(

--- a/eitprocessing/datahandling/sequence.py
+++ b/eitprocessing/datahandling/sequence.py
@@ -27,10 +27,9 @@ class Sequence(Equivalence, SelectByTime):
 
     A Sequence object is a representation of data points over time. These data can consist of any combination of EIT
     frames (`EITData`), waveform data (`ContinuousData`) from different sources, or individual events (`SparseData`)
-    occurring at any given timepoint.
-    A Sequence can consist of an entire measurement, a section of a measurement, a single breath, or even a portion of a
-    breath. A Sequence can consist of multiple sets of each type of data from the same time-points or can be a single
-    measurement from just one source.
+    occurring at any given timepoint. A Sequence can consist of an entire measurement, a section of a measurement, a
+    single breath, or even a portion of a breath. A Sequence can consist of multiple sets of each type of data from the
+    same time-points or can be a single measurement from just one source.
 
     A Sequence can be split up into separate sections of a measurement or multiple (similar) Sequence objects can be
     merged together to form a single Sequence.

--- a/eitprocessing/datahandling/sequence.py
+++ b/eitprocessing/datahandling/sequence.py
@@ -287,3 +287,15 @@ class _DataAccess:
             msg = f"Key {label} does not match object label {obj.label}."
             raise KeyError(msg)
         return self.add(obj)
+
+    def __contains__(self, label: str):
+        for container in (
+            self._sequence.continuous_data,
+            self._sequence.interval_data,
+            self._sequence.sparse_data,
+            self._sequence.eit_data,
+        ):
+            if label in container:
+                return True
+
+        return False

--- a/eitprocessing/datahandling/sequence.py
+++ b/eitprocessing/datahandling/sequence.py
@@ -178,17 +178,17 @@ class Sequence(Equivalence, SelectByTime):
     def data(self) -> _DataAccess:
         """Shortcut access to data stored in collections inside a sequence.
 
-        This allows all data objects stored in a collection inside a sequence can be accessed.
+        This allows all data objects stored in a collection inside a sequence to be accessed.
         Instead of `sequence.continuous_data["global_impedance"]` you can use
         `sequence.data["global_impedance"]`. This works for getting (`sequence.data["label"]` or
         `sequence.data.get("label")`) and adding data (`sequence.data["label"] = obj` or
-        `sequence.data.add("label", obj)`).
+        `sequence.data.add(obj)`).
 
         Other dict-like behaviour is also supported:
         - `label in sequence.data` to check whether an object with a label exists;
         - `del sequence.data[label]` to remove an object from the sequence based on the label;
         - `for label in sequence.data` to iterate over the labels;
-        - `sequence.data.items()` to retrieve a (list of label), object pairs, especially useful for iteration;
+        - `sequence.data.items()` to retrieve a list of (label, object) pairs, especially useful for iteration;
         - `sequence.data.labels()` or `sequence.data.keys()` to get a list of data labels;
         - `sequence.data.objects()` or `sequence.data.values()` to get a list of data objects.
 

--- a/eitprocessing/datahandling/sequence.py
+++ b/eitprocessing/datahandling/sequence.py
@@ -291,7 +291,7 @@ class _DataAccess:
 
     def __setitem__(self, label: str, obj: DataContainer):
         if obj.label != label:
-            msg = f"Key {label} does not match object label {obj.label}."
+            msg = f"Label {label} does not match object label {obj.label}."
             raise KeyError(msg)
         return self.add(obj)
 

--- a/eitprocessing/datahandling/sequence.py
+++ b/eitprocessing/datahandling/sequence.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import contextlib
 import itertools
+import sys
 from dataclasses import MISSING, dataclass, field
 from typing import TYPE_CHECKING, Any, TypeVar, overload
 
@@ -208,10 +208,11 @@ class _DataAccess:
             if duplicates := set(a) & set(b):
                 msg = f"Duplicate labels ({', '.join(sorted(duplicates))}) found in {a} and {b}."
                 exc = KeyError(msg)
-                with contextlib.suppress(AttributeError):
+                if sys.version_info >= (3, 11):
                     exc.add_note(
                         "You can't use the `data` interface with duplicate labels. "
-                        "Use the explicit data collections (`eit_data`, `continuous_data`, `sparse_data`, `interval_data`) instead."
+                        "Use the explicit data collections (`eit_data`, `continuous_data`, `sparse_data`, "
+                        "`interval_data`) instead."
                     )
                 raise exc
 
@@ -282,10 +283,11 @@ class _DataAccess:
             if self.get(object_.label, None):
                 msg = f"An object with the label {object_.label} already exists in this sequence."
                 exc = KeyError(msg)
-                with contextlib.suppress(AttributeError):
+                if sys.version_info >= (3, 11):
                     exc.add_note(
                         "You can't add an object with the same label through the `data` interface. "
-                        "Use the explicit data collections (`eit_data`, `continuous_data`, `sparse_data`, `interval_data`) instead."
+                        "Use the explicit data collections (`eit_data`, `continuous_data`, `sparse_data`, "
+                        "`interval_data`) instead."
                     )
                 raise exc
 

--- a/eitprocessing/datahandling/sequence.py
+++ b/eitprocessing/datahandling/sequence.py
@@ -252,7 +252,7 @@ class _DataAccess:
     def __getitem__(self, key: str) -> DataContainer:
         return self.get(key)
 
-    def add(self, obj: DataContainer) -> None:
+    def add(self, *obj: DataContainer) -> None:
         """Add a DataContainer object to the sequence.
 
         Adds the object to the appropriate data collection. The label of the object must be unique
@@ -264,19 +264,20 @@ class _DataAccess:
         Raises:
             KeyError: if the label of the object already exists in any of the data collections.
         """
-        if self.get(obj.label, None):
-            msg = f"An object with the label {obj.label} already exists in this sequence."
-            raise KeyError(msg)
+        for object_ in obj:
+            if self.get(object_.label, None):
+                msg = f"An object with the label {object_.label} already exists in this sequence."
+                raise KeyError(msg)
 
-        match obj:
-            case ContinuousData():
-                self._sequence.continuous_data.add(obj)
-            case IntervalData():
-                self._sequence.interval_data.add(obj)
-            case SparseData():
-                self._sequence.sparse_data.add(obj)
-            case EITData():
-                self._sequence.eit_data.add(obj)
+            match object_:
+                case ContinuousData():
+                    self._sequence.continuous_data.add(object_)
+                case IntervalData():
+                    self._sequence.interval_data.add(object_)
+                case SparseData():
+                    self._sequence.sparse_data.add(object_)
+                case EITData():
+                    self._sequence.eit_data.add(object_)
 
     def __setitem__(self, label: str, obj: DataContainer):
         if obj.label != label:

--- a/tests/test_sequence_data.py
+++ b/tests/test_sequence_data.py
@@ -108,9 +108,7 @@ def test_add_multiple(create_continuous_data_object: Callable, create_interval_d
     assert "bar" in sequence.data
 
 
-def test_duplicate_keys(
-    create_continuous_data_object: Callable, create_interval_data_object: Callable
-):
+def test_duplicate_keys(create_continuous_data_object: Callable, create_interval_data_object: Callable):
     sequence = Sequence()
 
     continuous_data_object = create_continuous_data_object("foo")
@@ -128,3 +126,50 @@ def test_duplicate_keys(
 
     with pytest.raises(KeyError):
         _ = sequence.data
+
+
+def test_delitem(create_continuous_data_object: Callable, create_interval_data_object: Callable):
+    sequence = Sequence()
+
+    continuous_data_object = create_continuous_data_object("foo")
+    interval_data_object = create_interval_data_object("bar")
+    sequence.data.add(continuous_data_object, interval_data_object)
+
+    assert "foo" in sequence.data
+    assert "bar" in sequence.data
+
+    del sequence.data["foo"]
+
+    assert "foo" not in sequence.data
+    assert continuous_data_object not in sequence.data.values()
+    assert "foo" not in sequence.continuous_data
+
+
+def test_lists_iter(create_continuous_data_object: Callable, create_interval_data_object: Callable):
+    sequence = Sequence()
+
+    continuous_data_object = create_continuous_data_object("foo")
+    interval_data_object = create_interval_data_object("bar")
+    sequence.data.add(continuous_data_object, interval_data_object)
+
+    assert set(sequence.data.keys()) == {"foo", "bar"}
+    assert set(sequence.data.labels()) == {"foo", "bar"}
+
+    # order is important! Ideally these would be converted to sets, but that is not possible due to missing hash
+    # functions
+    assert sequence.data.values() == [continuous_data_object, interval_data_object]
+    assert sequence.data.objects() == [continuous_data_object, interval_data_object]
+
+    iterator = iter(sequence.data)
+    a = next(iterator)
+    b = next(iterator)
+    assert a in ["foo", "bar"]
+    assert b in ["foo", "bar"]
+
+    with pytest.raises(StopIteration):
+        next(iterator)
+
+    assert dict(sequence.data.items()) == {
+        "foo": continuous_data_object,
+        "bar": interval_data_object,
+    }

--- a/tests/test_sequence_data.py
+++ b/tests/test_sequence_data.py
@@ -1,0 +1,111 @@
+from collections.abc import Callable
+
+import numpy as np
+import pytest
+
+from eitprocessing.datahandling.intervaldata import IntervalData
+from eitprocessing.datahandling.sequence import Sequence, _DataAccess
+from tests.test_breath_detection import ContinuousData
+
+
+@pytest.fixture
+def create_continuous_data_object():
+    return lambda label: ContinuousData(
+        label=label,
+        name="name",
+        unit="unit",
+        category="other",
+        time=np.array([]),
+        values=np.array([]),
+    )
+
+
+@pytest.fixture
+def create_interval_data_object():
+    return lambda label: IntervalData(
+        label=label,
+        name="name",
+        unit="unit",
+        category="other",
+        intervals=[],
+        values=[],
+    )
+
+
+def test_init():
+    sequence = Sequence()
+
+    assert isinstance(sequence.data, _DataAccess)
+    assert hasattr(sequence.data, "get")
+    assert hasattr(sequence.data, "add")
+
+
+def test_get(create_continuous_data_object: Callable, create_interval_data_object: Callable):
+    sequence = Sequence()
+
+    assert sequence.data.get("foo", None) is None
+    assert "foo" not in sequence.data
+
+    with pytest.raises(KeyError):
+        sequence.data.get("foo")
+
+    with pytest.raises(KeyError):
+        sequence.data["foo"]
+
+    continuous_data_object = create_continuous_data_object("foo")
+    sequence.continuous_data.add(continuous_data_object)
+
+    assert continuous_data_object in sequence.continuous_data.values()
+    assert sequence.data.get("foo", None) is continuous_data_object
+    assert "foo" in sequence.data
+    assert sequence.data.get("foo") is continuous_data_object
+    assert sequence.data["foo"] is continuous_data_object
+
+    interval_data_object = create_interval_data_object("bar")
+    sequence.interval_data.add(interval_data_object)
+
+    assert interval_data_object in sequence.interval_data.values()
+    assert sequence.data.get("bar", None) is interval_data_object
+    assert "bar" in sequence.data
+    assert sequence.data.get("bar") is interval_data_object
+    assert sequence.data["bar"] is interval_data_object
+
+
+def test_add(create_continuous_data_object: Callable, create_interval_data_object: Callable):
+    sequence = Sequence()
+
+    continuous_data_object = create_continuous_data_object("foo")
+    sequence.data.add(continuous_data_object)
+
+    assert "foo" in sequence.data
+    assert continuous_data_object in sequence.continuous_data.values()
+
+    interval_data_object = create_interval_data_object("bar")
+    sequence.data["bar"] = interval_data_object
+
+    assert "bar" in sequence.data
+    assert interval_data_object in sequence.interval_data.values()
+
+    continuous_data_object_2 = create_continuous_data_object("foobar")
+    with pytest.raises(KeyError):
+        sequence.data["not foobar"] = continuous_data_object_2
+
+
+def test_duplicate_keys(create_continuous_data_object: Callable, create_interval_data_object: Callable):
+    sequence = Sequence()
+
+    continuous_data_object = create_continuous_data_object("foo")
+    sequence.continuous_data.add(continuous_data_object)
+
+    assert "foo" in sequence.continuous_data
+
+    interval_data_object = create_interval_data_object("foo")
+
+    with pytest.raises(KeyError):
+        sequence.data.add(interval_data_object)
+
+    # you can still add through the DataCollection, but this interface will not be available anymore
+    sequence.interval_data.add(interval_data_object)
+
+    with pytest.raises(KeyError):
+        _ = sequence.data

--- a/tests/test_sequence_data.py
+++ b/tests/test_sequence_data.py
@@ -97,7 +97,20 @@ def test_add(create_continuous_data_object: Callable, create_interval_data_objec
         sequence.data["not foobar"] = continuous_data_object_2
 
 
-def test_duplicate_keys(create_continuous_data_object: Callable, create_interval_data_object: Callable):
+def test_add_multiple(create_continuous_data_object: Callable, create_interval_data_object: Callable):
+    sequence = Sequence()
+
+    continuous_data_object = create_continuous_data_object("foo")
+    interval_data_object = create_interval_data_object("bar")
+
+    sequence.data.add(continuous_data_object, interval_data_object)
+    assert "foo" in sequence.data
+    assert "bar" in sequence.data
+
+
+def test_duplicate_keys(
+    create_continuous_data_object: Callable, create_interval_data_object: Callable
+):
     sequence = Sequence()
 
     continuous_data_object = create_continuous_data_object("foo")

--- a/tests/test_sequence_data.py
+++ b/tests/test_sequence_data.py
@@ -36,6 +36,12 @@ def test_init():
     sequence = Sequence()
 
     assert isinstance(sequence.data, _DataAccess)
+    assert sequence.data._collections == (
+        sequence.continuous_data,
+        sequence.interval_data,
+        sequence.sparse_data,
+        sequence.eit_data,
+    )
     assert hasattr(sequence.data, "get")
     assert hasattr(sequence.data, "add")
 


### PR DESCRIPTION
This PR adds a data interface to sequences for easier access to data objects. Instead of `sequence.continuous_data['filtered impedance']` one can now use `sequence.data['filtered impedance']`. Adding data is also easier with `sequence.data.add(object)

Other dict function are also implemented, such that `sequence.data` can be used as a conglomeration of all data collections. 

This improves readability of end user code. The old interface is still intact and usable. To use the interface, all labels have to be unique across all data collections. 

Fixes #363