### PR TITLE
Add exception when trying to filter data with NaN-values

### DIFF
--- a/eitprocessing/filters/butterworth_filters.py
+++ b/eitprocessing/filters/butterworth_filters.py
@@ -1,3 +1,4 @@
+import sys
 from dataclasses import InitVar, dataclass
 from typing import Literal
 
@@ -142,6 +143,15 @@ class ButterworthFilter(TimeDomainFilter):
         Returns:
             The filtered output with the same shape as the input data.
         """
+        if np.any(np.isnan(input_data)):
+            msg = "Input data contains NaN-values."
+            exc = ValueError(msg)
+            if sys.version_info >= (3, 11):
+                exc.add_note(
+                    "Butterworth filters can't handle data containing NaN-values. "
+                    "You can fill in gaps using `np.nan_to_num(...)` or interpolation."
+                )
+            raise exc
         sos = signal.butter(
             N=self.order,
             Wn=self.cutoff_frequency,

--- a/tests/test_butterworth_filter.py
+++ b/tests/test_butterworth_filter.py
@@ -286,3 +286,14 @@ def test_butterworth_functionality():
             signal_,
             axis,
         )
+
+
+def test_nan_values(filter_arguments: dict):
+    filter_ = ButterworthFilter(**filter_arguments)
+    data = np.random.default_rng().random(1000)
+
+    _ = filter_.apply_filter(data)
+
+    data[100] = np.nan
+    with pytest.raises(ValueError):
+        _ = filter_.apply_filter(data)


### PR DESCRIPTION
The Butterworth filters can't handle data with NaN-values. Currently, if you pass data with NaN-values to `apply_filter(...)`, it will silently return an array with all-NaN-data. This is difficult to debug.

This PR adds a check that raises an exception when the data to be filtered contains any NaN values. It also tips the user on how to fix the problem.