### PR TITLE
Update pip caching

### DIFF
--- a/.github/actions/install_eitprocessing/action.yml
+++ b/.github/actions/install_eitprocessing/action.yml
@@ -44,6 +44,5 @@ runs:
         path: ~/.cache/pip
         key: ${{ inputs.python-version }}-${{ hashFiles('pyproject.toml') }}-[${{ inputs.dependencies }}]
     - name: Install eitprocessing with [${{ inputs.dependencies }}] dependencies
-      if: steps.cache-python-env.outputs.cache-hit != 'true'
       run: python3 -m pip install ".[${{ inputs.dependencies }}]"
       shell: bash

--- a/.github/actions/install_eitprocessing/action.yml
+++ b/.github/actions/install_eitprocessing/action.yml
@@ -41,8 +41,8 @@ runs:
     - uses: actions/cache@v4
       id: cache-python-env
       with:
-        path: ${{ env.pythonLocation }}
-        key: ${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml') }}-[${{ inputs.dependencies }}]
+        path: ~/.cache/pip
+        key: ${{ inputs.python-version }}-${{ hashFiles('pyproject.toml') }}-[${{ inputs.dependencies }}]
     - name: Install eitprocessing with [${{ inputs.dependencies }}] dependencies
       if: steps.cache-python-env.outputs.cache-hit != 'true'
       run: python3 -m pip install ".[${{ inputs.dependencies }}]"


### PR DESCRIPTION
Apparently, we cached the entire python install directory, which lead to permission issues. We had to manually remove caches before to keep the workflow running. This update caches only the downloaded packages, which is not prone to the same permission issues. 