### PR TITLE
Add PixelMaskCollection class

### DIFF
--- a/docs/api/roi/pixelmaskcollection.md
+++ b/docs/api/roi/pixelmaskcollection.md
@@ -1,0 +1,1 @@
+::: eitprocessing.roi.pixelmaskcollection

--- a/docs/api/roi/roi.md
+++ b/docs/api/roi/roi.md
@@ -1,0 +1,4 @@
+::: eitprocessing.roi
+    options:
+        members:
+            - PixelMask

--- a/eitprocessing/roi/__init__.py
+++ b/eitprocessing/roi/__init__.py
@@ -76,6 +76,7 @@ class PixelMask:
     """
 
     mask: np.ndarray
+    label: str | None = None
     keep_zeros: InitVar[bool] = field(default=False, kw_only=True)
     suppress_value_range_error: InitVar[bool] = field(default=False, kw_only=True)
     suppress_zero_conversion_warning: InitVar[bool] = field(default=False, kw_only=True)
@@ -83,6 +84,8 @@ class PixelMask:
     def __init__(
         self,
         mask: list | np.ndarray,
+        *,
+        label: str | None = None,
         keep_zeros: bool = False,
         suppress_value_range_error: bool = False,
         suppress_zero_conversion_warning: bool = False,
@@ -119,6 +122,7 @@ class PixelMask:
 
         mask.flags["WRITEABLE"] = False
         object.__setattr__(self, "mask", mask)
+        object.__setattr__(self, "label", label)
 
     update = replace
     # TODO: add tests for update

--- a/eitprocessing/roi/__init__.py
+++ b/eitprocessing/roi/__init__.py
@@ -24,7 +24,7 @@ vice versa.
 import dataclasses
 import sys
 import warnings
-from dataclasses import InitVar, dataclass, field
+from dataclasses import InitVar, dataclass, field, replace
 from dataclasses import replace as dataclass_replace
 from typing import TypeVar, overload
 
@@ -119,6 +119,9 @@ class PixelMask:
 
         mask.flags["WRITEABLE"] = False
         object.__setattr__(self, "mask", mask)
+
+    update = replace
+    # TODO: add tests for update
 
     @overload
     def apply(self, data: np.ndarray) -> np.ndarray: ...

--- a/eitprocessing/roi/pixelmaskcollection.py
+++ b/eitprocessing/roi/pixelmaskcollection.py
@@ -34,6 +34,7 @@ class PixelMaskCollection:
     mapping each mask's key (label or index) to the resulting masked data.
 
     Example:
+    ```python
     >>> mask_collection = PixelMaskCollection(
             [
                 PixelMask(right_lung_data, label="right lung"),
@@ -41,6 +42,7 @@ class PixelMaskCollection:
             ],
             label="lung masks",
         )
+    ```
 
     Args:
         masks (dict): A dictionary mapping mask names to their corresponding pixel masks.
@@ -125,8 +127,10 @@ class PixelMaskCollection:
         Masks can be added as positional arguments or keyword arguments (non-anonymous masks only).
 
         Example:
+        ```python
         >>> left_lung_mask = PixelMask(data, label="left_lung")
         >>> mask_collection.add(left_lung_mask)  # equals mask_collection.add(left_lung=left_lung_mask)
+        ```
 
         Args:
             *mask (PixelMask): One or more `PixelMask` instances to add to the collection.
@@ -135,7 +139,7 @@ class PixelMaskCollection:
                 Keyword arguments where the key is the label of the mask and the value is the mask itself.
 
         Returns:
-        A new `PixelMaskCollection` instance with the added masks.
+            A new `PixelMaskCollection` instance with the added masks.
 
         Raises:
             ValueError:
@@ -197,6 +201,15 @@ class PixelMaskCollection:
         union of the represented ROIs. If "product" is used, the masks are multiplied, generally resulting in the
         intersection of the ROIs.
 
+        Example:
+        ```python
+        >>> pm1 = PixelMask([[True, False], [False, True]])
+        >>> pm2 = PixelMask([[True, True], [False, False]])
+        >>> collection = PixelMaskCollection([pm1, pm2])
+        >>> summed_mask = collection.combine(method="sum")
+        PixelMask(mask=array([[ 1.,  1.], [nan,  1.]]))
+        ```
+
         Args:
             method (Literal["sum", "product"]): The method to combine the masks. Defaults to "sum".
             label (str | None): The label for the combined mask.
@@ -239,12 +252,14 @@ class PixelMaskCollection:
         `ValueError`.
 
         Example:
+        ```python
         >>> mask_collection = PixelMaskCollection([
                 PixelMask(data, label="right lung"),
                 PixelMask(data, label="left lung")
             ])
         >>> mask_collection.apply(eit_data, label_format="masked {mask_label}")
         {"right lung": EITData(label="masked right lung"), "left lung": EITData(label="masked left lung")}
+        ```
 
         Args:
             data (np.ndarray | EITData | PixelMap): The data to which the masks will be applied.

--- a/eitprocessing/roi/pixelmaskcollection.py
+++ b/eitprocessing/roi/pixelmaskcollection.py
@@ -1,0 +1,284 @@
+import warnings
+from collections.abc import Hashable
+from dataclasses import dataclass, field, replace
+from typing import TypeVar, cast, overload
+
+import numpy as np
+from frozendict import frozendict
+from typing_extensions import Self
+
+from eitprocessing.datahandling.eitdata import EITData
+from eitprocessing.datahandling.pixelmap import PixelMap
+from eitprocessing.roi import PixelMask
+
+T = TypeVar("T", bound=EITData | PixelMap)
+
+
+@dataclass(frozen=True)
+class PixelMaskCollection:
+    """A collection of pixel masks, each representing a specific region of interest (ROI) in the EIT data.
+
+    This class allows for the application of multiple masks to numpy arrays, EIT data or pixel maps, enabling the
+    extraction of specific regions based on the defined masks.
+
+    PixelMasks can be labelled with strings, or anonymous (`label=None`). Either all or none of the masks should have a
+    label; it is not possible to mix labelled and unlabelled masks.
+
+    At initialization, masks can be provided as a list or a dictionary. If provided as a list, the masks are converted
+    to a dictionary with either their labels as keys (if all masks have labels) or their indices as keys (if none have
+    labels). If provided as a dictionary, the keys must match the labels of the masks; anonymous PixelMaps can not be
+    provided as a dictionary.
+
+    When the `apply` method is called, it applies each mask to the provided data and returns a dictionary
+    mapping each mask's key (label or index) to the resulting masked data.
+
+    Example:
+    >>> mask_collection = PixelMaskCollection(
+            [
+                PixelMask(right_lung_data, label="right lung"),
+                PixelMask(left_lung_data, label="left lung"),
+            ],
+            label="lung masks",
+        )
+
+    Args:
+        masks (dict): A dictionary mapping mask names to their corresponding pixel masks.
+        label (str | None): An optional label for the collection of masks.
+
+    Attributes:
+        is_anonymous (bool):
+            A boolean indicating whether all masks in the collection are anonymous (i.e., have no label).
+
+    """
+
+    masks: frozendict[Hashable, PixelMask]
+    label: str | None = field(default=None)
+
+    def __init__(
+        self,
+        masks: dict[Hashable, PixelMask] | frozendict[Hashable, PixelMask] | list[PixelMask],
+        *,
+        label: str | None = None,
+    ):
+        object.__setattr__(self, "masks", self._validate_and_convert_input_masks(masks))
+        object.__setattr__(self, "label", label)
+
+    def _validate_and_convert_input_masks(
+        self, masks: dict[Hashable, PixelMask] | frozendict[Hashable, PixelMask] | list[PixelMask]
+    ) -> frozendict[Hashable, PixelMask]:
+        """Validate the input masks and convert to a frozendict.
+
+        The input masks are valid if:
+        - The input is a list with all labelled or all anonymous PixelMask instances.
+        - The input is a dictionary where each PixelMask instance's label matches the key.
+        """
+        # Check for type before checking for length, e.g., and empty string should raise a TypeError, not ValueError
+        if not isinstance(masks, (list, dict, frozendict)):
+            msg = f"Expected a list or a dictionary, got {type(masks)}."
+            raise TypeError(msg)
+
+        if not masks:
+            msg = "A PixelMaskCollection should contain at least one mask."
+            raise ValueError(msg)
+
+        if isinstance(masks, list):
+            return self._validate_and_convert_list_input(masks)
+
+        return self._validate_and_convert_dict_input(masks)
+
+    def _validate_and_convert_list_input(self, masks: list[PixelMask]) -> frozendict[Hashable, PixelMask]:
+        if any(not isinstance(mask, PixelMask) for mask in masks):
+            msg = "All items in the collection must be instances of PixelMask."
+            raise TypeError(msg)
+        if all(mask.label is None for mask in masks):
+            return frozendict(enumerate(masks))
+        if all(isinstance(mask.label, str) for mask in masks):
+            return frozendict({cast("str", mask.label): mask for mask in masks})
+
+        msg = "Cannot mix labelled and anonymous masks in a collection."
+        raise ValueError(msg)
+
+    def _validate_and_convert_dict_input(
+        self, masks: dict[Hashable, PixelMask] | frozendict[Hashable, PixelMask]
+    ) -> frozendict[Hashable, PixelMask]:
+        if any(not isinstance(mask, PixelMask) for mask in masks.values()):
+            msg = "All items in the collection must be instances of PixelMask."
+            raise TypeError(msg)
+        if all(mask.label is None for mask in masks.values()):
+            if set(masks.keys()) != set(range(len(masks))):
+                msg = "Anonymous masks should be indexed with consecutive integers starting from 0."
+                raise ValueError(msg)
+        elif any(mask.label != key for key, mask in masks.items()):
+            msg = "Keys should match the masks' label."
+            raise KeyError(msg)
+        return frozendict(masks)
+
+    @property
+    def is_anonymous(self) -> bool:
+        """Check if all masks in the collection are anonymous (i.e., have no label)."""
+        return all(mask.label is None for mask in self.masks.values())
+
+    def add(self, *mask: PixelMask, overwrite: bool = False, **kwargs) -> Self:
+        """Return a new collection with one or more masks added.
+
+        Masks can be added as positional arguments or keyword arguments (non-anonymous masks only).
+
+        Example:
+        >>> left_lung_mask = PixelMask(data, label="left_lung")
+        >>> mask_collection.add(left_lung_mask)  # equals mask_collection.add(left_lung=left_lung_mask)
+
+        Args:
+            *mask (PixelMask): One or more `PixelMask` instances to add to the collection.
+            overwrite (bool): If True, allows overwriting existing masks with the same label or index.
+            **kwargs (PixelMask):
+                Keyword arguments where the key is the label of the mask and the value is the mask itself.
+
+        Returns:
+        A new `PixelMaskCollection` instance with the added masks.
+
+        Raises:
+            ValueError:
+                If no masks are provided, if trying to mix labelled and unlabelled masks, or if provided keys don't
+                match the masks label.
+            KeyError: If trying to overwrite an existing mask without setting `overwrite`.
+        """
+        if not mask and not kwargs:
+            msg = "No masks provided to add."
+            raise ValueError(msg)
+
+        if self.is_anonymous:
+            return self._add_to_anonymous(mask, kwargs, overwrite)
+
+        return self._add_to_labelled(mask, kwargs, overwrite)
+
+    def _add_to_anonymous(self, masks: tuple[PixelMask, ...], kwargs: dict[str, PixelMask], overwrite: bool) -> Self:
+        if overwrite:
+            warnings.warn(
+                "Cannot overwrite existing masks in an anonymous collection. All masks with be added instead.",
+                UserWarning,
+            )
+        if kwargs:
+            msg = "Cannot mix labelled and anonymous masks in a collection."
+            raise ValueError(msg)
+        if not all(mask_.label is None for mask_ in masks):
+            msg = "Cannot mix labelled and anonymous masks in a collection."
+            raise ValueError(msg)
+        return self.update(masks=self.masks | dict(enumerate(masks, start=len(self.masks))))
+
+    def _add_to_labelled(self, masks: tuple[PixelMask, ...], kwargs: dict[str, PixelMask], overwrite: bool) -> Self:
+        new_masks: dict[str, PixelMask] = {}
+
+        if masks:
+            if any(mask.label is None for mask in masks):
+                msg = "Cannot mix labelled and anonymous masks in a collection."
+                raise ValueError(msg)
+
+            if not overwrite and any(mask_.label in self.masks for mask_ in masks):
+                msg = "Cannot overwrite mask with the same key unless 'overwrite' is set to True."
+                raise KeyError(msg)
+
+            new_masks = new_masks | {cast("str", mask.label): mask for mask in masks}
+
+        if kwargs:
+            if not overwrite and any(key in self.masks for key in kwargs):
+                msg = "Cannot overwrite mask with the same key unless 'overwrite' is set to True."
+                raise KeyError(msg)
+            new_masks = new_masks | kwargs
+
+        return self.update(masks=self.masks | new_masks)
+
+    update = replace  # dataclasses.replace
+
+    @overload
+    def apply(self, data: np.ndarray) -> dict[Hashable, np.ndarray]: ...
+
+    @overload
+    def apply(self, data: EITData, *, label_format: str | None = None, **kwargs) -> dict[Hashable, EITData]: ...
+
+    @overload
+    def apply(self, data: PixelMap, *, label_format: str | None = None, **kwargs) -> dict[Hashable, PixelMap]: ...
+
+    def apply(self, data, *, label_format: str | None = None, **kwargs):
+        """Apply the masks to the provided data.
+
+        The input data can be a numpy array, EITData, or PixelMap. The method applies each mask in the collection to the
+        data and returns a dictionary mapping each mask's key (label or index) to the resulting masked data.
+
+        If `label_format` is provided, it should be a format string that includes `{mask_label}`. This label will be
+        passed to the resulting objects, with the appropriate mask label applied. If `label_format` is not provided, no
+        label will be provided.
+
+        Additional keyword arguments are passed to the `update` of the EITData or PixelMap, if applicable. If the input
+        data is a numpy array, `label_format` and additional keyword arguments are not applicable and will raise a
+        `ValueError`.
+
+        Example:
+        >>> mask_collection = PixelMaskCollection([
+                PixelMask(data, label="right lung"),
+                PixelMask(data, label="left lung")
+            ])
+        >>> mask_collection.apply(eit_data, label_format="masked {mask_label}")
+        {"right lung": EITData(label="masked right lung"), "left lung": EITData(label="masked left lung")}
+
+        Args:
+            data (np.ndarray | EITData | PixelMap): The data to which the masks will be applied.
+            label_format (str | None): A format string to create the label of the returned EITData or PixelMap objects.
+            **kwargs:
+                Additional keyword arguments to pass to the `update` method of the returned EITData or PixelMap objects.
+
+        Returns:
+            A dictionary mapping each mask's key (label or index) to the resulting masked data.
+
+        Raises:
+            ValueError: If a label is passed as a keyword argument.
+            ValueError:
+                If label_format or additional keyword arguments are provided when the input data is a numpy array.
+            ValueError: If provided label format does not contain '{mask_label}'.
+            TypeError: If provided data is not an array, EITData, or PixelMap.
+        """
+        if "label" in kwargs:
+            msg = "Cannot pass 'label' as a keyword argument to `apply()`. Use 'label_format' instead."
+            raise ValueError(msg)
+
+        match data:
+            case np.ndarray():
+                return self._apply_mask_array(data, label_format, **kwargs)
+            case EITData():
+                return self._apply_mask_data(data, label_format, **kwargs)
+            case PixelMap():
+                # The extra case seems superfluous, but is required for type checking; _apply_mask_data() returns a dict
+                # with the values the same type as the input data, which is not clear if the cases EITData and PixelMap
+                # are not separated.
+                return self._apply_mask_data(data, label_format, **kwargs)
+            case _:
+                msg = f"Unsupported data type: {type(data)}"
+                raise TypeError(msg)
+
+    def _apply_mask_array(self, data: np.ndarray, label_format: str | None, **kwargs) -> dict[Hashable, np.ndarray]:
+        if label_format is not None:
+            msg = "label_format is not applicable for numpy arrays."
+            raise ValueError(msg)
+        if kwargs:
+            msg = "Additional keyword arguments are not applicable for numpy arrays."
+            raise ValueError(msg)
+        return {key: mask.apply(data) for key, mask in self.masks.items()}
+
+    def _apply_mask_data(self, data: T, label_format: str | None, **kwargs) -> dict[Hashable, T]:
+        def get_label(key: Hashable) -> str | None:
+            """Format the label with the mask_label, provided `label_format` is not None."""
+            if label_format is None:
+                return None
+            try:
+                formatted_label = label_format.format(mask_label=key)
+            except IndexError as e:
+                msg = f"Invalid label format: {label_format}."
+                raise ValueError(msg) from e
+            except KeyError as e:
+                msg = f"Invalid label format: {label_format}."
+                raise ValueError(msg) from e
+            if formatted_label == label_format:
+                msg = "Invalid label format. Label format does not contain '{mask_label}'. Cannot format label."
+                raise ValueError(msg)
+            return formatted_label
+
+        return {key: mask.apply(data, label=get_label(key), **kwargs) for key, mask in self.masks.items()}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,6 +60,9 @@ nav:
         - Event: api/datacontainers/event.md
         - DataCollection: api/datacontainers/datacollection.md
       - api/filters.md
+      - Regions of Interest:
+        - Regions of Interest: api/roi/roi.md
+        - PixelMaskCollection: api/roi/pixelmaskcollection.md
       - api/features.md
       - api/parameters.md
       - api/categories.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,8 @@ omit = ["tests/*", "*/tests/*"]
 [tool.coverage.report]
 exclude_lines = [
     "if TYPE_CHECKING:",
-    "if sys\\.version_info"
+    "if sys\\.version_info",
+    "@overload"
 ]
 
 [tool.setuptools.packages.find]

--- a/tests/test_pixelmask_collection.py
+++ b/tests/test_pixelmask_collection.py
@@ -448,3 +448,31 @@ def test_update_method(anonymous_boolean_mask: Callable):
     assert collection.label is None
     assert updated_collection1.label == "first"
     assert updated_collection2.label == "second"
+
+
+def test_combine_boolean():
+    pm1 = PixelMask([[True, False], [False, True]])
+    pm2 = PixelMask([[True, True], [False, False]])
+    collection = PixelMaskCollection([pm1, pm2])
+
+    summed_mask = collection.combine(method="sum", label="combined_sum")
+    assert summed_mask.label == "combined_sum"
+    assert np.array_equal(summed_mask.mask, np.array([[1.0, 1.0], [np.nan, 1.0]]), equal_nan=True)
+
+    multiplied_mask = collection.combine(method="product", label="combined_product")
+    assert multiplied_mask.label == "combined_product"
+    assert np.array_equal(multiplied_mask.mask, np.array([[1.0, np.nan], [np.nan, np.nan]]), equal_nan=True)
+
+
+def test_combine_weighted():
+    pm1 = PixelMask([[0, 0.1], [0.2, 1]], suppress_zero_conversion_warning=True)
+    pm2 = PixelMask([[1, 1], [0.3, 0.2]])
+    collection = PixelMaskCollection([pm1, pm2])
+
+    summed_mask = collection.combine(method="sum", label="combined_sum")
+    assert summed_mask.label == "combined_sum"
+    assert np.array_equal(summed_mask.mask, np.array([[1.0, 1.0], [0.5, 1.0]]), equal_nan=True)
+
+    multiplied_mask = collection.combine(method="product", label="combined_product")
+    assert multiplied_mask.label == "combined_product"
+    assert np.array_equal(multiplied_mask.mask, np.array([[np.nan, 0.1], [0.06, 0.2]]), equal_nan=True)

--- a/tests/test_pixelmask_collection.py
+++ b/tests/test_pixelmask_collection.py
@@ -1,0 +1,450 @@
+from collections.abc import Callable
+
+import numpy as np
+import pytest
+
+from eitprocessing.datahandling.eitdata import EITData
+from eitprocessing.datahandling.pixelmap import PixelMap
+from eitprocessing.datahandling.sequence import Sequence
+from eitprocessing.roi import PixelMask
+from eitprocessing.roi.pixelmaskcollection import PixelMaskCollection
+
+
+@pytest.fixture
+def numpy_array() -> Callable:
+    return lambda: np.random.default_rng().random((32, 32))
+
+
+@pytest.fixture
+def pixel_map(numpy_array: Callable) -> Callable:
+    return lambda: PixelMap(numpy_array(), label="test_map")
+
+
+@pytest.fixture
+def anonymous_boolean_mask(numpy_array: Callable) -> Callable:
+    return lambda: PixelMask(numpy_array() > 0.5)
+
+
+@pytest.fixture
+def labelled_boolean_mask(anonymous_boolean_mask: Callable):
+    return lambda label: anonymous_boolean_mask().update(label=label)
+
+
+@pytest.fixture
+def anonymous_float_mask(numpy_array: Callable) -> Callable:
+    def factory() -> PixelMask:
+        numpy_array_ = numpy_array() * 1.2 - 0.2
+        numpy_array_[numpy_array_ <= 0] = np.nan
+        return PixelMask(numpy_array_)
+
+    return factory
+
+
+@pytest.fixture
+def labelled_float_mask(anonymous_float_mask: Callable) -> Callable:
+    return lambda label: anonymous_float_mask().update(label=label)
+
+
+def test_boolean_mask_factory_unique(anonymous_boolean_mask: Callable):
+    mask1 = anonymous_boolean_mask()
+    mask2 = anonymous_boolean_mask()
+    assert not np.array_equal(mask1.mask, mask2.mask)
+
+
+def test_float_mask_factory_unique(anonymous_float_mask: Callable):
+    mask1 = anonymous_float_mask()
+    mask2 = anonymous_float_mask()
+    assert not np.array_equal(mask1.mask, mask2.mask)
+
+
+def test_init_with_label(anonymous_boolean_mask: Callable):
+    mask = anonymous_boolean_mask()
+    collection = PixelMaskCollection([mask], label="test_collection")
+    assert collection.label == "test_collection"
+
+
+def test_init_without_label(anonymous_boolean_mask: Callable):
+    mask = anonymous_boolean_mask()
+    collection = PixelMaskCollection([mask])
+    assert collection.label is None
+
+
+def test_init_with_labelled_masks(labelled_boolean_mask: Callable):
+    pm1 = labelled_boolean_mask("mask1")
+    pm2 = labelled_boolean_mask("mask2")
+    collection1 = PixelMaskCollection([pm1, pm2])
+    assert collection1.masks == {"mask1": pm1, "mask2": pm2}
+
+    collection2 = PixelMaskCollection({"mask2": pm2, "mask1": pm1})
+    assert collection2 == collection1
+
+
+def test_init_with_anonymous_masks(anonymous_boolean_mask: Callable):
+    pm1 = anonymous_boolean_mask()
+    pm2 = anonymous_boolean_mask()
+    collection1 = PixelMaskCollection([pm1, pm2])
+    assert collection1.masks == {0: pm1, 1: pm2}
+
+    collection2 = PixelMaskCollection({0: pm1, 1: pm2})
+    assert collection1 == collection2
+
+
+def test_init_with_dict_integer_keys_unordered_raises(anonymous_boolean_mask: Callable):
+    pm1 = anonymous_boolean_mask()
+    pm2 = anonymous_boolean_mask()
+
+    _ = PixelMaskCollection({1: pm1, 0: pm2})  # the order does not matter
+
+    with pytest.raises(
+        ValueError, match="Anonymous masks should be indexed with consecutive integers starting from 0."
+    ):
+        _ = PixelMaskCollection({1: pm1, 2: pm2})
+
+    with pytest.raises(
+        ValueError, match="Anonymous masks should be indexed with consecutive integers starting from 0."
+    ):
+        _ = PixelMaskCollection({0: pm1, 2: pm2})
+
+    with pytest.raises(
+        ValueError, match="Anonymous masks should be indexed with consecutive integers starting from 0."
+    ):
+        _ = PixelMaskCollection({0: pm1, -1: pm2})
+
+
+def test_init_with_mixed_labelled_and_anonymous_masks_raises(
+    labelled_boolean_mask: Callable, anonymous_boolean_mask: Callable
+):
+    pm1 = labelled_boolean_mask("mask1")
+    pm2 = anonymous_boolean_mask()
+    with pytest.raises(ValueError, match="Cannot mix labelled and anonymous masks in a collection."):
+        PixelMaskCollection([pm1, pm2])
+
+
+def test_init_with_dict_label_mismatch_raises(labelled_boolean_mask: Callable):
+    pm1 = labelled_boolean_mask("mask1")
+    pm2 = labelled_boolean_mask("mask2")
+    with pytest.raises(KeyError, match="Keys should match the masks' label."):
+        PixelMaskCollection({"mask1": pm1, "mask3": pm2})
+
+
+def test_init_with_wrong_input_raises(anonymous_boolean_mask: Callable):
+    with pytest.raises(TypeError, match="Expected a list or a dictionary, got"):
+        _ = PixelMaskCollection((anonymous_boolean_mask(),))
+
+    with pytest.raises(TypeError, match="Expected a list or a dictionary, got"):
+        _ = PixelMaskCollection(anonymous_boolean_mask())
+
+    with pytest.raises(TypeError, match="Expected a list or a dictionary, got"):
+        _ = PixelMaskCollection(0)
+
+
+def test_init_with_non_pixelmasks_raises():
+    with pytest.raises(TypeError, match="All items in the collection must be instances of PixelMask."):
+        _ = PixelMaskCollection([1, 2, 3])
+
+    with pytest.raises(TypeError, match="All items in the collection must be instances of PixelMask."):
+        _ = PixelMaskCollection({"mask1": 1, "mask2": 2})
+
+
+def test_is_anonymous_property_labelled(labelled_boolean_mask: Callable):
+    pm = labelled_boolean_mask("mask1")
+    collection = PixelMaskCollection([pm])
+    assert not collection.is_anonymous
+
+
+def test_is_anonymous_property_anonymous(anonymous_boolean_mask: Callable):
+    pm = anonymous_boolean_mask()
+    collection = PixelMaskCollection([pm])
+    assert collection.is_anonymous
+
+
+def test_apply_to_numpy_array_labelled(labelled_boolean_mask: Callable, numpy_array: Callable):
+    pm1 = labelled_boolean_mask("mask1")
+    pm2 = labelled_boolean_mask("mask2")
+
+    data = numpy_array()
+
+    collection = PixelMaskCollection([pm1, pm2])
+    result = collection.apply(data)
+
+    assert len(result) == 2
+    assert isinstance(result, dict)
+    assert all(isinstance(value, np.ndarray) for value in result.values())
+    assert all(isinstance(key, str) for key in result)
+    assert result.keys() == collection.masks.keys()
+
+    assert np.array_equal(result["mask1"], pm1.apply(data), equal_nan=True)
+    assert np.array_equal(result["mask2"], pm2.apply(data), equal_nan=True)
+
+
+def test_apply_to_numpy_array_anonymous(anonymous_boolean_mask: Callable, numpy_array: Callable):
+    pm1 = anonymous_boolean_mask()
+    pm2 = anonymous_boolean_mask()
+
+    data = numpy_array()
+
+    collection = PixelMaskCollection([pm1, pm2])
+    result = collection.apply(data)
+
+    assert len(result) == 2
+    assert isinstance(result, dict)
+    assert all(isinstance(value, np.ndarray) for value in result.values())
+    assert all(isinstance(key, int) for key in result)
+    assert result.keys() == collection.masks.keys()
+
+    assert np.array_equal(result[0], pm1.apply(data), equal_nan=True)
+    assert np.array_equal(result[1], pm2.apply(data), equal_nan=True)
+
+
+def test_apply_to_numpy_data_label_format(anonymous_boolean_mask: Callable, numpy_array: Callable):
+    pm1 = anonymous_boolean_mask()
+    pm2 = anonymous_boolean_mask()
+
+    data = numpy_array()
+
+    collection = PixelMaskCollection([pm1, pm2])
+    with pytest.raises(ValueError, match=r"label_format is not applicable"):
+        _ = collection.apply(data, label_format="masked_{mask_label}")
+
+
+def test_apply_to_eitdata_labelled(draeger1: Sequence, labelled_boolean_mask: Callable):
+    eit_data = draeger1.eit_data["raw"][:100]
+
+    pm1 = labelled_boolean_mask("mask1")
+    pm2 = labelled_boolean_mask("mask2")
+    collection = PixelMaskCollection([pm1, pm2])
+    result = collection.apply(eit_data)
+
+    assert isinstance(result, dict)
+    assert len(result) == 2
+    assert all(isinstance(value, EITData) for value in result.values())
+    assert all(isinstance(key, str) for key in result)
+    assert result.keys() == collection.masks.keys()
+
+    assert np.array_equal(result["mask1"].pixel_impedance, pm1.apply(eit_data).pixel_impedance, equal_nan=True)
+    assert np.array_equal(result["mask2"].pixel_impedance, pm2.apply(eit_data).pixel_impedance, equal_nan=True)
+
+    # Results should be the same if providing pixel_impedance array directly
+    assert np.array_equal(result["mask1"].pixel_impedance, pm1.apply(eit_data.pixel_impedance), equal_nan=True)
+    assert np.array_equal(result["mask2"].pixel_impedance, pm2.apply(eit_data.pixel_impedance), equal_nan=True)
+
+
+def test_apply_to_pixelmap_labelled(pixel_map: Callable, labelled_boolean_mask: Callable):
+    pixel_map_instance = pixel_map()
+
+    pm1 = labelled_boolean_mask("mask1")
+    pm2 = labelled_boolean_mask("mask2")
+    collection = PixelMaskCollection([pm1, pm2])
+    result = collection.apply(pixel_map_instance)
+
+    assert isinstance(result, dict)
+    assert len(result) == 2
+    assert all(isinstance(value, PixelMap) for value in result.values())
+    assert all(isinstance(key, str) for key in result)
+    assert result.keys() == collection.masks.keys()
+
+    assert np.array_equal(result["mask1"].values, pm1.apply(pixel_map_instance).values, equal_nan=True)
+    assert np.array_equal(result["mask2"].values, pm2.apply(pixel_map_instance).values, equal_nan=True)
+
+    assert np.array_equal(result["mask1"].values, pm1.apply(pixel_map_instance.values), equal_nan=True)
+    assert np.array_equal(result["mask2"].values, pm2.apply(pixel_map_instance.values), equal_nan=True)
+
+
+def test_apply_with_label_format(pixel_map: Callable, labelled_boolean_mask: Callable):
+    pixel_map_instance = pixel_map()
+
+    pm1 = labelled_boolean_mask("mask1")
+    pm2 = labelled_boolean_mask("mask2")
+    collection = PixelMaskCollection([pm1, pm2])
+
+    result = collection.apply(pixel_map_instance, label_format="masked_{mask_label}")
+
+    assert set(result.keys()) == {"mask1", "mask2"}
+    assert result["mask1"].label == "masked_mask1"
+    assert result["mask2"].label == "masked_mask2"
+
+
+def test_apply_with_invalid_label_format_raises(pixel_map: Callable, labelled_boolean_mask: Callable):
+    pixel_map_instance = pixel_map()
+
+    collection = PixelMaskCollection([labelled_boolean_mask("mask1"), labelled_boolean_mask("mask2")])
+
+    with pytest.raises(ValueError, match="Invalid label format"):
+        _ = collection.apply(pixel_map_instance, label_format="masked_{}")
+
+    with pytest.raises(ValueError, match="Invalid label format. Label format does not contain '{mask_label}'."):
+        _ = collection.apply(pixel_map_instance, label_format="masked")
+
+    with pytest.raises(ValueError, match="Invalid label format"):
+        _ = collection.apply(pixel_map_instance, label_format="{mask_label} {}")
+
+    with pytest.raises(ValueError, match="Invalid label format"):
+        _ = collection.apply(pixel_map_instance, label_format="{mask_label} {something_else}")
+
+
+def test_apply_with_invalid_data_type_raises(labelled_boolean_mask: Callable, draeger1: Sequence):
+    collection = PixelMaskCollection([labelled_boolean_mask("mask1"), labelled_boolean_mask("mask2")])
+
+    with pytest.raises(TypeError, match="Unsupported data type:"):
+        _ = collection.apply("invalid_data")
+
+    with pytest.raises(TypeError, match="Unsupported data type:"):
+        _ = collection.apply([[1, 2]])
+
+    with pytest.raises(TypeError, match="Unsupported data type:"):
+        _ = collection.apply(draeger1)
+
+
+def test_apply_with_label_keyword_raises(labelled_boolean_mask: Callable, pixel_map: Callable):
+    pixel_map_instance = pixel_map()
+    collection = PixelMaskCollection([labelled_boolean_mask("mask1"), labelled_boolean_mask("mask2")])
+
+    with pytest.raises(ValueError, match=r"Cannot pass 'label' as a keyword argument to `apply\(\)`."):
+        _ = collection.apply(pixel_map_instance, label="test")
+
+
+def test_apply_with_extra_kwargs_on_array_raises(labelled_boolean_mask: Callable, numpy_array: Callable):
+    array = numpy_array()
+    collection = PixelMaskCollection([labelled_boolean_mask("mask1"), labelled_boolean_mask("mask2")])
+
+    with pytest.raises(ValueError, match=r"Additional keyword arguments are not applicable for numpy arrays."):
+        _ = collection.apply(array, sample_frequency="test")
+
+
+def test_empty_collection_raises():
+    with pytest.raises(ValueError, match="A PixelMaskCollection should contain at least one mask."):
+        _ = PixelMaskCollection([])
+
+    with pytest.raises(ValueError, match="A PixelMaskCollection should contain at least one mask."):
+        _ = PixelMaskCollection({})
+
+    with pytest.raises(
+        TypeError, match=r"PixelMaskCollection.__init__\(\) missing 1 required positional argument: 'masks'"
+    ):
+        _ = PixelMaskCollection()
+
+
+def test_add_labelled_mask(labelled_boolean_mask: Callable):
+    collection = PixelMaskCollection([labelled_boolean_mask("existing_mask")])
+
+    new_mask1 = labelled_boolean_mask("new_mask1")
+    new_mask2 = labelled_boolean_mask("new_mask2")
+    updated_collection = collection.add(new_mask1, new_mask2)
+
+    assert len(collection.masks) == 1
+
+    assert len(updated_collection.masks) == 3
+    assert "new_mask1" in updated_collection.masks
+    assert "new_mask2" in updated_collection.masks
+    assert new_mask1 is updated_collection.masks["new_mask1"]
+    assert new_mask2 is updated_collection.masks["new_mask2"]
+
+
+def test_add_anonymous_mask(anonymous_boolean_mask: Callable):
+    collection = PixelMaskCollection([anonymous_boolean_mask()])
+
+    new_mask1 = anonymous_boolean_mask()
+    new_mask2 = anonymous_boolean_mask()
+    updated_collection = collection.add(new_mask1, new_mask2)
+
+    assert len(collection.masks) == 1
+
+    assert len(updated_collection.masks) == 3
+    assert new_mask1 is updated_collection.masks[1]
+    assert new_mask2 is updated_collection.masks[2]
+
+
+def test_add_labelled_mask_overwrite(labelled_boolean_mask: Callable):
+    existing_mask = labelled_boolean_mask("existing_mask")
+    collection = PixelMaskCollection([existing_mask])
+    assert collection.masks["existing_mask"] is existing_mask
+
+    new_mask = labelled_boolean_mask("existing_mask")
+
+    updated_collection1 = collection.add(new_mask, overwrite=True)
+    assert len(collection.masks) == 1
+    assert len(updated_collection1.masks) == 1
+    assert updated_collection1.masks["existing_mask"] is new_mask
+
+    updated_collection2 = collection.add(existing_mask=new_mask, overwrite=True)
+    assert updated_collection2.masks["existing_mask"] is new_mask
+
+
+def test_add_labelled_mask_duplicate_raises(labelled_boolean_mask: Callable):
+    collection = PixelMaskCollection([labelled_boolean_mask("existing_mask")])
+
+    new_mask = labelled_boolean_mask("existing_mask")
+
+    with pytest.raises(KeyError, match="Cannot overwrite mask with the same key unless"):
+        _ = collection.add(new_mask, overwrite=False)
+
+    with pytest.raises(KeyError, match="Cannot overwrite mask with the same key unless"):
+        _ = collection.add(new_mask)
+
+    with pytest.raises(KeyError, match="Cannot overwrite mask with the same key unless"):
+        _ = collection.add(existing_mask=new_mask)
+
+
+def test_add_anonymous_mask_to_labelled_collection_raises(
+    labelled_boolean_mask: Callable, anonymous_boolean_mask: Callable
+):
+    collection = PixelMaskCollection([labelled_boolean_mask("existing_mask")])
+    new_mask = anonymous_boolean_mask()
+
+    with pytest.raises(ValueError, match="Cannot mix labelled and anonymous masks in a collection."):
+        _ = collection.add(new_mask)
+
+
+def test_add_labelled_mask_to_anonymous_collection_raises(
+    labelled_boolean_mask: Callable, anonymous_boolean_mask: Callable
+):
+    collection = PixelMaskCollection([anonymous_boolean_mask()])
+    new_mask = labelled_boolean_mask("existing_mask")
+
+    with pytest.raises(ValueError, match="Cannot mix labelled and anonymous masks in a collection."):
+        _ = collection.add(new_mask)
+
+
+def test_add_keyword_mask_to_anonymous_collection_raises(anonymous_boolean_mask: Callable):
+    collection = PixelMaskCollection([anonymous_boolean_mask()])
+    new_mask = anonymous_boolean_mask()
+
+    with pytest.raises(ValueError, match="Cannot mix labelled and anonymous masks in a collection."):
+        _ = collection.add(new_mask=new_mask)
+
+
+def test_add_keyword_wrong_key_raises(labelled_boolean_mask: Callable):
+    collection = PixelMaskCollection([labelled_boolean_mask("existing_mask")])
+    new_mask = labelled_boolean_mask("new_mask")
+
+    with pytest.raises(KeyError, match="Keys should match the masks' label."):
+        _ = collection.add(other_key=new_mask)
+
+
+def test_add_none_raises(anonymous_boolean_mask: Callable):
+    collection = PixelMaskCollection([anonymous_boolean_mask()])
+    with pytest.raises(ValueError, match="No masks provided to add."):
+        _ = collection.add()
+
+
+def test_add_anonymous_overwrite_warning(anonymous_boolean_mask: Callable):
+    collection = PixelMaskCollection([anonymous_boolean_mask()])
+    with pytest.warns(
+        UserWarning,
+        match="Cannot overwrite existing masks in an anonymous collection. All masks with be added instead.",
+    ):
+        _ = collection.add(anonymous_boolean_mask(), overwrite=True)
+
+
+def test_update_method(anonymous_boolean_mask: Callable):
+    collection = PixelMaskCollection([anonymous_boolean_mask()])
+    assert collection.label is None
+
+    updated_collection1 = collection.update(label="first")
+    assert collection.label is None
+    assert updated_collection1.label == "first"
+
+    updated_collection2 = updated_collection1.update(label="second")
+    assert collection.label is None
+    assert updated_collection1.label == "first"
+    assert updated_collection2.label == "second"


### PR DESCRIPTION
This PR add the PixelMaskCollection class, based on the recently added PixelMask.

The main goal for this class is to be able to apply multiple masks to data, returning a dictionary of individual results. You can also combine the contained masks into a single mask by summing them ("sum") or multiplying them ("product"). 

Masks in a collection can be labelled or anonymous. Labelled is useful when working with pre-defined masks, e.g., 'ventral' and 'dorsal', while anonymous masks are useful when working with an unpredictable number of masks, e.g., ROI definition based on thresholds resulting in multiple separate areas that can be independently labelled. 