### PR TITLE
Fix mkdocs dependencies

### DIFF
--- a/eitprocessing/plotting/filter.py
+++ b/eitprocessing/plotting/filter.py
@@ -1,7 +1,7 @@
+from dataclasses import dataclass
 from typing import TypeVar
 
 import numpy as np
-from attr import dataclass
 from matplotlib import axes, figure
 from matplotlib import pyplot as plt
 from scipy import signal

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,14 +60,14 @@ dev = [
 ]
 testing = ["pytest >= 7.4.0, < 8.4.0", "pytest-cov", "coveralls"]
 docs = [
-    "mkdocs",
-    "mkdocs-material",
-    "mkdocstrings",
-    "mkdocstrings-python",
-    "mkdocs-exclude",
-    "mike",
-    "pymdown-extensions",
-    "black",
+    "mkdocs >= 1.6.1",
+    "mkdocs-material >= 9.6.18",
+    "mkdocstrings >= 0.30.0",
+    "mkdocstrings-python >= 1.17.0",
+    "mkdocs-exclude >= 1.0.2",
+    "mike >= 2.1.3",
+    "pymdown-extensions >= 10.16.1",
+    "black >= 25.1.0",
     "mkdocs-jupyter >=0.25.1",
 ]
 notebooks = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,6 @@ dependencies = [
     "typing_extensions",
     "pyyaml",
     "frozendict>=2.4.6",
-    "mkdocs-jupyter>=0.25.1",
     "scikit-image>=0.25.2",
 ]
 
@@ -69,6 +68,7 @@ docs = [
     "mike",
     "pymdown-extensions",
     "black",
+    "mkdocs-jupyter >=0.25.1",
 ]
 notebooks = [
     "jupyter >= 1.0.0",


### PR DESCRIPTION
Mkdocs dependencies get a minimum version. Also, the `mkdocs-jupyter` dependency is moved from the general group to the docs group.

As a testament to why this was necessary: apparently one module imported `dataclass` from `attrs` instead of `dataclasses`. This was not caught by tests partly because `attrs` was installed due to the `mkdocs-jupyter` dependency, and thus could be imported. This import is also fixed in this PR.