### PR TITLE
Fix deployment of documentation

### DIFF
--- a/.github/workflows/test_build_documentation.yml
+++ b/.github/workflows/test_build_documentation.yml
@@ -15,10 +15,6 @@ jobs:
     if: github.event.pull_request.draft == false
     name: Build documentation
     runs-on: ubuntu-latest
-    permissions:
-      pages: write
-    strategy:
-      fail-fast: false
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/test_build_documentation.yml
+++ b/.github/workflows/test_build_documentation.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Build documentation
         if: ${{ !(github.event_name == 'push' && github.ref == 'refs/heads/main') }}
         run: mkdocs build
-      - name: Deploy documentation
+      - name: Build and deploy documentation
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/test_build_documentation.yml
+++ b/.github/workflows/test_build_documentation.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - develop
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:

--- a/.github/workflows/test_build_documentation.yml
+++ b/.github/workflows/test_build_documentation.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Link notebooks
         run: ln -s ../../notebooks docs/examples
       - name: Build documentation
+        if: ${{ !(github.event_name == 'push' && github.ref == 'refs/heads/main') }}
         run: mkdocs build
       - name: Deploy documentation
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}

--- a/.github/workflows/test_build_documentation.yml
+++ b/.github/workflows/test_build_documentation.yml
@@ -24,10 +24,10 @@ jobs:
           dependencies: docs
           extract-data: false
           python-version: "3.10"
+      - name: Link notebooks
+        run: ln -s ../../notebooks docs/examples
       - name: Build documentation
-        run: |
-          ln -s ../../notebooks docs/examples
-          mkdocs build
+        run: mkdocs build
       - name: Deploy documentation
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         run: |

--- a/.github/workflows/test_build_documentation.yml
+++ b/.github/workflows/test_build_documentation.yml
@@ -32,5 +32,6 @@ jobs:
       - name: Deploy documentation
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         run: |
-          GIT_COMMITTER_NAME=ci-bot GIT_COMMITTER_EMAIL=ci-bot@github.com \
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
           mike deploy --push --update-aliases $(git describe --tags --abbrev=0 | sed -E 's/^([vV]?[0-9]+\.[0-9]+).*/\1/') latest

--- a/.github/workflows/test_build_documentation.yml
+++ b/.github/workflows/test_build_documentation.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.GH_PAT }}
       - uses: ./.github/actions/install_eitprocessing
         with:
           dependencies: docs


### PR DESCRIPTION
Should close #428.

Deployment did not work due to permissions issues. This PR adds a personal access token to the checkout action, which sets up the permission properly, as tested in a separate repo. 

Also cleans up the action to reduce redundancy and clarify steps.