### PR TITLE
Update github release workflow

### DIFF
--- a/.github/workflows/release_github.yml
+++ b/.github/workflows/release_github.yml
@@ -174,7 +174,7 @@ jobs:
 
       - name: Merge PR
         run: |
-          gh pr merge ${{ github.ref_name }} --merge --delete-branch --squash=false
+          gh pr merge ${{ github.ref_name }} --merge --delete-branch --squash=false --admin
 
       - name: Wait for main to update
         id: waitmain


### PR DESCRIPTION
This PR fixed an issue where release or fix PRs would not be merged, but had to be closed after merging. Also, removing the PR branch was not consistent.