### PR TITLE
Fix Python version targeted by ruff to earliest supported version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,7 @@ eitprocessing = ["config/*.yaml", "py.typed"]
 output-format = "concise"
 line-length = 120
 extend-include = ["*.ipynb"]
+target-version = "py310"
 
 [tool.ruff.lint]
 select = ["ALL"]


### PR DESCRIPTION
ruff changes behavior depending on the version it targets. To prevent unnecessary fixed by ruff, this PR fixes the targeted version in pyproject.toml.