### PR TITLE
Add global ROI definition

### DIFF
--- a/eitprocessing/roi/__init__.py
+++ b/eitprocessing/roi/__init__.py
@@ -4,21 +4,8 @@ This module contains tools for the selection of regions of interest and masking 
 module is `PixelMask`. Any type of region of interest selection results in a `PixelMask` object. A mask can be applied
 to any pixel dataset (EITData, PixelMap) with the same shape.
 
-Several default masks have been predefined. NB: the right side of the patient is to the left side of the EIT image and
-vice versa.
-
-- `VENTRAL_MASK` includes only the first 16 rows;
-- `DORSAL_MASK` includes only the last 16 rows;
-- `ANATOMICAL_RIGHT_MASK` includes only the first 16 columns;
-- `ANATOMICAL_LEFT_MASK` includes only the last 16 columns;
-- `QUADRANT_1_MASK` includes the top right quadrant;
-- `QUADRANT_2_MASK` includes the top left quadrant;
-- `QUADRANT_3_MASK` includes the bottom right quadrant;
-- `QUADRANT_4_MASK` includes the bottom left quadrant;
-- `LAYER_1_MASK` includes only the first 8 rows;
-- `LAYER_2_MASK` includes only the second set of 8 rows;
-- `LAYER_3_MASK` includes only the third set of 8 rows;
-- `LAYER_4_MASK` includes only the last 8 rows.
+Predefined default masks can be created using `get_geometric_mask()`. These masks are based on common anatomical regions
+of interest.
 """
 
 from __future__ import annotations

--- a/tests/test_pixelmask.py
+++ b/tests/test_pixelmask.py
@@ -221,6 +221,14 @@ def test_pixelmask_subtract():
 
 
 @pytest.mark.parametrize("shape", [(32, 1), (64, 1), (16, 1), (100, 1), (4, 1)])
+def test_predefined_global_mask(shape: tuple[int, int]):
+    global_mask = get_geometric_mask("global", shape)
+    assert global_mask.label == "global"
+    assert global_mask.shape == shape
+    assert np.all(global_mask.mask == 1.0)
+
+
+@pytest.mark.parametrize("shape", [(32, 1), (64, 1), (16, 1), (100, 1), (4, 1)])
 def test_predefined_layer_masks(shape: tuple[int, int]):
     quarter_height = shape[0] // 4
     first = slice(None, quarter_height)


### PR DESCRIPTION
This PR adds a global ROI definition. This may seem unuseful at first, because application should not alter the input data. However, for automation purposes, it is useful to treat global the same as other ROI definitions. By having a global mask, it can be treated the same as any other mask.

This PR also removed outdated documentation.